### PR TITLE
COSerialization: ignore unknown attributes in COItem

### DIFF
--- a/Core/COSerialization.m
+++ b/Core/COSerialization.m
@@ -954,10 +954,11 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 	
 		if (propertyDesc == nil)
 		{
-			[NSException raise: NSInvalidArgumentException
-			            format: @"Tried to set serialized value %@ of type %@ "
-			                     "for property %@ missing in the metamodel %@",
-			                    serializedValue, COTypeDescription(serializedType), property, [self entityDescription]];
+			// Was an exception in 0.5, but that seems overly paranoid
+			NSLog(@"Warning: Tried to set serialized value %@ of type %@ "
+				   "for property %@ missing in the metamodel %@",
+				   serializedValue, COTypeDescription(serializedType), property, [self entityDescription]);
+			continue;
 		}
 
 		id value = [self valueForSerializedValue: serializedValue

--- a/Tests/Core/TestSerialization.m
+++ b/Tests/Core/TestSerialization.m
@@ -59,4 +59,20 @@
 	UKObjectsEqual(@"COAttachmentID", [[[[deserializedObject entityDescription] propertyDescriptionForName: @"attachmentID"] type] name]);
 }
 
+- (void) testUnknowItemAttributes
+{
+	COPersistentRoot *proot = [ctx insertNewPersistentRootWithEntityName: @"Anonymous.OutlineItem"];
+	COObject *rootObject = [proot rootObject];
+	COMutableItem *item = [[rootObject storeItem] mutableCopy];
+	
+	[item setValue: @"foo" forAttribute: @"bar" type: kCOTypeString];
+	
+	COItemGraph *itemGr = [[COItemGraph alloc] initWithItems: @[item] rootItemUUID: item.UUID];
+	COObjectGraphContext *newCtx = [COObjectGraphContext new];
+	
+	// @"foo" : @"bar" should not cause a problem, it should be ignored
+	// during deserialization
+	UKDoesNotRaiseException([newCtx setItemGraph: itemGr]);
+}
+
 @end


### PR DESCRIPTION
-[COObject(COSerialization) setStoreItem:]: Change from exception to NSLog warning when encountering a key in the COItem that's not in the metamodel. Test included.

An example of why this is helpful: if we had this from the start, the recent JSON change (adding a format tag) would be readable by old CoreObject versions. Also, the current schema migration design for what constitutes a breaking change depends on this.