### PR TITLE
Hidden dead cross persistent root refs

### DIFF
--- a/Core/COBranch.m
+++ b/Core/COBranch.m
@@ -136,6 +136,11 @@ parentRevisionForNewBranch: (ETUUID *)parentRevisionForNewBranch
     return [_persistentRoot editingContext];
 }
 
+/**
+ * For the interaction with cross persistent root references, see
+ * -[COPersistentRoot setCurrentBranchObjectGraphToRevisionUUID:persistentRootUUID:]
+ * whose discussion applies this method unfaulting logic in the same way.
+ */
 - (COObjectGraphContext *) objectGraphContext
 {
 	if (_objectGraph == nil)

--- a/Core/COCrossPersistentRootDeadRelationshipCache.h
+++ b/Core/COCrossPersistentRootDeadRelationshipCache.h
@@ -1,0 +1,56 @@
+/**
+	Copyright (C) 2015 Quentin Mathe
+
+	Date:  May 2015
+	License:  MIT  (see COPYING)
+ */
+
+#import <Foundation/Foundation.h>
+#import <EtoileFoundation/EtoileFoundation.h>
+
+@class COPath, COObject;
+
+/**
+ * An instance of this class is owned by each COEditingContext, to cache 
+ * incoming relationships for deleted (and possibly finalized) persistent roots.
+ *
+ * For deleted persistent roots or branches, the root object is not present in 
+ * memory, so we cannot track incoming relationships accross persistent roots 
+ * using the usual relationship cache that exists per object.
+ *
+ * When a persistent root or branch is undeleted, we use this cache to know 
+ * which other persistent roots outgoing relationships must be fixed to point to 
+ * the resurrected root object. To fix outgoing relationships accross persistent 
+ * roots, we replace dead COPath references hidden in the COPrimitiveCollection 
+ * backing by alive COObject references.
+ */
+@interface COCrossPersistentRootDeadRelationshipCache : NSObject
+{
+	@private
+	NSMutableDictionary *_pathToReferringObjects;
+	NSMapTable *_referringObjectToPaths;
+}
+
+- (void)addReferringObject: (COObject *)aReferrer
+                   forPath: (COPath *)aPath;
+- (NSHashTable *)referringObjectsForPath: (COPath *)aPath;
+- (void)removeReferringObject: (COObject *)aReferrer
+                      forPath: (COPath *)aPath;
+- (void)removeReferringObject: (COObject *)aReferrer;
+/**
+ * Removes all referring objects for the path.
+ *
+ * When a persistent root or branch is undeleted or finalized, this method
+ * should be called with a persistent root path that corresponds to the
+ * undeletion/finalization target.
+ * When a persistent root or branch is unloaded, any matching paths should be 
+ * kept in the cache, in case it gets reloaded later (we cannot figure out cross 
+ * persistent root incoming relationships from the reloading).
+ *
+ * For referring object graph contexts, when unloaded or finalized, the
+ * deallocation will trigger their removal of their inner objects from the hash 
+ * tables in the cache on 10.8 or iOS 6 or higher, but not on 10.7.
+ */
+- (void)removePath: (COPath *)aPath;
+
+@end

--- a/Core/COCrossPersistentRootDeadRelationshipCache.m
+++ b/Core/COCrossPersistentRootDeadRelationshipCache.m
@@ -1,0 +1,93 @@
+/*
+	Copyright (C) 2015 Quentin Mathe
+
+	Date:  July 2015
+	License:  MIT  (see COPYING)
+ */
+
+#import "COCrossPersistentRootDeadRelationshipCache.h"
+#import "COPath.h"
+#import "COPersistentRoot.h"
+
+//#define MISSING_ZEROING_WEAK_REF
+
+@implementation COCrossPersistentRootDeadRelationshipCache
+
+- (id)init
+{
+	SUPERINIT;
+	_pathToReferringObjects = [NSMutableDictionary new];
+#if TARGET_OS_IPHONE
+	_referringObjectToPaths = [NSMapTable weakToStrongObjectsMapTable];
+#else
+	_referringObjectToPaths = [NSMapTable mapTableWithWeakToStrongObjects];
+#endif
+	return self;
+}
+
+- (void)addReferringObject: (COObject *)aReferrer
+                   forPath: (COPath *)aPath
+{
+	NSHashTable *referringObjects = _pathToReferringObjects[aPath];
+	NSMutableSet *paths = [_referringObjectToPaths objectForKey: aReferrer];
+
+	if (referringObjects == nil)
+	{
+		// FIXME: If we don't ditch 10.7 support, we need a reverse mapping
+		// from each referringObject to a path set, that can be used to remove
+		// the referring objects when their object graph context is discarded.
+#if TARGET_OS_IPHONE
+		referringObjects = [NSHashTable weakObjectsHashTable];
+#else
+		referringObjects = [NSHashTable hashTableWithWeakObjects];
+#endif
+ 
+		_pathToReferringObjects[aPath] = referringObjects;
+	}
+	if (paths == nil)
+	{
+		paths = [NSMutableSet new];
+		[_referringObjectToPaths setObject: paths
+		                            forKey: aReferrer];
+	}
+	[paths addObject: aPath];
+	[referringObjects addObject: aReferrer];
+}
+
+- (NSHashTable *)referringObjectsForPath: (COPath *)aPath
+{
+	return _pathToReferringObjects[aPath];
+}
+
+- (void)removeReferringObject: (COObject *)aReferrer
+                      forPath: (COPath *)aPath
+{
+	NSMutableSet *paths = [_referringObjectToPaths objectForKey: aReferrer];
+
+	[paths removeObject: aPath];
+	[_pathToReferringObjects[aPath] removeObject: aReferrer];
+}
+
+- (void)removeReferringObject: (COObject *)aReferrer
+{
+	NSMutableSet *paths = [_referringObjectToPaths objectForKey: aReferrer];
+	
+	if (paths == nil)
+		return;
+
+	[_referringObjectToPaths removeObjectForKey: aReferrer];
+	[_pathToReferringObjects removeObjectsForKeys: paths.allObjects];
+}
+
+- (void)removePath: (COPath *)aPath
+{
+	NSHashTable *referringObjects = _pathToReferringObjects[aPath];
+
+	for (COObject *referrer in referringObjects)
+	{
+		[_referringObjectToPaths removeObjectForKey: referrer];
+	}
+	[_pathToReferringObjects removeObjectForKey: aPath];
+}
+
+@end

--- a/Core/COCrossPersistentRootDeadRelationshipCache.m
+++ b/Core/COCrossPersistentRootDeadRelationshipCache.m
@@ -1,7 +1,7 @@
 /*
 	Copyright (C) 2015 Quentin Mathe
 
-	Date:  July 2015
+	Date:  May 2015
 	License:  MIT  (see COPYING)
  */
 

--- a/Core/COEditingContext+Private.h
+++ b/Core/COEditingContext+Private.h
@@ -8,7 +8,7 @@
 #import <CoreObject/COEditingContext.h>
 #import <CoreObject/CORevision.h>
 
-@class COPath, COUndoTrack;
+@class  COCrossPersistentRootDeadRelationshipCache, COPath, COUndoTrack;
 
 @interface COEditingContext ()
 
@@ -54,6 +54,10 @@
 restrictedToPersistentRoots: (NSArray *)persistentRoots
 			 withUndoTrack: (COUndoTrack *)track
 					 error: (COError **)anError;
+/**
+ * This property is only exposed to be used internally by CoreObject.
+ */
+@property (nonatomic, readonly) COCrossPersistentRootDeadRelationshipCache *deadRelationshipCache;
 /**
  * This method is only exposed to be used internally by CoreObject.
  */

--- a/Core/COEditingContext+Private.h
+++ b/Core/COEditingContext+Private.h
@@ -65,6 +65,12 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
 /**
  * This method is only exposed to be used internally by CoreObject.
  */
+- (void)updateCrossPersistentRootReferencesToPersistentRoot: (COPersistentRoot *)aPersistentRoot
+                                                     branch: (COBranch *)aBranch
+                                                  isDeleted: (BOOL)isDeletion;
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
 - (void)deletePersistentRoot: (COPersistentRoot *)aPersistentRoot;
 /**
  * This method is only exposed to be used internally by CoreObject.

--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -10,7 +10,7 @@
 #import <CoreObject/COPersistentObjectContext.h>
 
 @class COSQLiteStore, COEditingContext, COPersistentRoot, COBranch, COObjectGraphContext, COObject;
-@class COUndoTrack, COCommandGroup, CORevisionCache;
+@class COUndoTrack, COCommandGroup, COCrossPersistentRootDeadRelationshipCache, CORevisionCache;
 @class COError;
 
 /**
@@ -129,6 +129,7 @@
 	NSMutableSet *_persistentRootsPendingDeletion;
     /** Set of persistent roots pending undeletion */
 	NSMutableSet *_persistentRootsPendingUndeletion;
+	COCrossPersistentRootDeadRelationshipCache *_deadRelationshipCache;
     /** Undo */
     BOOL _isRecordingUndo;
     COCommandGroup *_currentEditGroup;

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -377,6 +377,9 @@
 	{
 		if (persistentRoot == aPersistentRoot)
 			continue;
+		
+		// TODO: Use -objectGraphWithoutUnfaulting to prevent loading every
+		// object graph contexts we check
 
 		/* Fix references pointing to any branch that belong to the deleted 
 		   persistent root (the relationship target) */

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -318,6 +318,13 @@
     {
         [_persistentRootsPendingUndeletion addObject: aPersistentRoot];
     }
+	
+	for (COPersistentRoot *persistentRoot in [_loadedPersistentRoots objectEnumerator])
+	{
+		// TODO: Fix references in other branches too
+		[persistentRoot.objectGraphContext replaceObject: nil
+											  withObject: aPersistentRoot.rootObject];
+	}
 }
 
 - (void)unloadPersistentRoot: (COPersistentRoot *)aPersistentRoot

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -18,6 +18,7 @@
 #import "COBranch+Private.h"
 #import "COPath.h"
 #import "COObjectGraphContext.h"
+#import "COObjectGraphContext+Private.h"
 #import "COEditingContext+Undo.h"
 #import "COEditingContext+Private.h"
 #import "CORevisionCache.h"
@@ -298,6 +299,13 @@
         // NOTE: Deleted persistent roots are removed from the cache on commit.
         [_persistentRootsPendingDeletion addObject: aPersistentRoot];
     }
+
+	for (COPersistentRoot *persistentRoot in [_loadedPersistentRoots objectEnumerator])
+	{
+		// TODO: Fix references in other branches too
+		[persistentRoot.objectGraphContext replaceObject: aPersistentRoot.rootObject
+		                                      withObject: nil];
+	}
 }
 
 - (void)undeletePersistentRoot: (COPersistentRoot *)aPersistentRoot

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -164,6 +164,13 @@
 
 #pragma mark Managing Persistent Roots -
 
+/**
+ * We don't need to update cross persistent references when loading a persistent 
+ * root, see -[COPersistentRoot setCurrentBranchObjectGraphToRevisionUUID:persistentRootUUID:].
+ *
+ * There is one exception to this rule, it's when we reload due to an external 
+ * change as covered in -storePersistentRootsDidChange:isDistributed:.
+ */
 - (COPersistentRoot *)persistentRootForUUID: (ETUUID *)persistentRootUUID
 {
 	COPersistentRoot *persistentRoot = [_loadedPersistentRoots objectForKey: persistentRootUUID];
@@ -178,9 +185,6 @@
 		return nil;
 
 	persistentRoot = [self makePersistentRootWithInfo: info objectGraphContext: nil];
-	[self updateCrossPersistentRootReferencesToPersistentRoot: persistentRoot
-	                                                   branch: nil
-	                                                isDeleted: persistentRoot.isDeleted];
 
 	return persistentRoot;
 }
@@ -357,6 +361,8 @@
  * <item>implicit deletion/undeletion when reloading persistent roots or branches 
  * (e.g. isTargetDeletion comment).</item>
  * </list>
+ *
+ * See also -[COPersistentRoot setCurrentBranchObjectGraphToRevisionUUID:persistentRootUUID:].
  */
 - (void)updateCrossPersistentRootReferencesToPersistentRoot: (COPersistentRoot *)aPersistentRoot
                                                      branch: (COBranch *)aBranch

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -447,16 +447,10 @@
 	ETUUID *branchUUID = [aPath branch];
 
 	COPersistentRoot *persistentRoot = [self persistentRootForUUID: persistentRootUUID];
-	// FIXME: We will need to handle the case where a reference points to a
-	// persistent root that has been permanently deleted from the store,
-	// perhaps by allocating a placeholder "broken link" persistent root.
-    ETAssert(persistentRoot != nil);
-	
-	if (branchUUID != nil)
+
+if (branchUUID != nil)
 	{
 		COBranch *branch = [persistentRoot branchForUUID: branchUUID];
-		// FIXME: Again, this is a simplification, should handle broken refs.
-		ETAssert(branch != nil);
 		
 		return [branch rootObject];
 	}

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -661,8 +661,8 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
 															  forPersistentRoot: uuid];
 		}
 		
-		/* Update _persistentRootsPendingDeletion and _persistentRootsPendingUndeletion and unload
-		   persistent roots. */
+		/* Update persistent roots and branches pending deletion and undeletion, 
+		   and unload persistent roots */
 		
 		for (COPersistentRoot *persistentRoot in persistentRoots)
 		{
@@ -676,9 +676,9 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
 			{
 				[_persistentRootsPendingUndeletion removeObject: persistentRoot];
 			}
+			[persistentRoot clearBranchesPendingDeletionAndUndeletion];
 		}
-												
-					
+
 		ETAssert([_store commitStoreTransaction: transaction]);
 		COCommandGroup *command = [self recordEndUndoGroupWithUndoTrack: track];
 		

--- a/Core/COObject+Private.h
+++ b/Core/COObject+Private.h
@@ -68,6 +68,10 @@
 /**
  * This method is only exposed to be used internally by CoreObject.
  */
+- (id)serializableValueForStorageKey: (NSString *)key;
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
 - (void)setValue: (id)value forStorageKey: (NSString *)key;
 /**
  * This method is only exposed to be used internally by CoreObject.

--- a/Core/COObject+Private.h
+++ b/Core/COObject+Private.h
@@ -12,7 +12,10 @@
 @class CORelationshipCache, COObjectGraphContext;
 
 @interface COObject ()
-
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
+- (Class)coreObjectCollectionClassForPropertyDescription: (ETPropertyDescription *)propDesc;
 /**
  * This method is only exposed to be used internally by CoreObject.
  *

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1473,6 +1473,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
  */
 - (void) replaceReferencesToObjectIdenticalTo: (COObject *)anObject withObject: (COObject *)aReplacement
 {
+	id object = (anObject != nil ? anObject : [COPath pathWithPersistentRoot: aReplacement.persistentRoot.UUID branch: aReplacement.branch.UUID]);
 	id replacement = (aReplacement != nil ? aReplacement : [COPath pathWithPersistentRoot: anObject.persistentRoot.UUID branch: anObject.branch.UUID]);
 
 	for (NSString *key in [self persistentPropertyNames])
@@ -1480,8 +1481,8 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 		id value = [self valueForStorageKey: key];
 		if (value == anObject)
 		{
-			// TODO: Use 'replacement' to support undeletion but will require
-			// some changes in -valueFor(Variable)StorageKey:
+			// TODO: Use 'object' and 'replacement' to support undeletion but
+			// will require some changes in -valueFor(Variable)StorageKey:
 			[self setValue: aReplacement forVariableStorageKey: key];
 		}
 		else if ([value isKindOfClass: [COMutableArray class]])
@@ -1492,7 +1493,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 			array.mutable = YES;
 			for (NSUInteger i=0; i<count; i++)
 			{
-				if (array[i] == anObject)
+				if (array[i] == object)
 				{
 					[array replaceReferenceAtIndex: i withReference: replacement];
 				}
@@ -1504,9 +1505,9 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 			COMutableSet *set = value;
 			
 			set.mutable = YES;
-			if ([set containsObject: anObject])
+			if ([set containsReference: object])
 			{
-				[set removeReference: anObject];
+				[set removeReference: object];
 				[set addReference: replacement];
 			}
 			set.mutable = NO;

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1566,9 +1566,9 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 					if (!updated)
 					{
 						[self willChangeValueForProperty: key];
+						updated = YES;
 					}
 					[array replaceReferenceAtIndex: i withReference: replacement];
-					updated = YES;
 				}
 			}
 			array.mutable = NO;
@@ -1583,10 +1583,10 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 				if (!updated)
 				{
 					[self willChangeValueForProperty: key];
+					updated = YES;
 				}
 				[set removeReference: object];
 				[set addReference: replacement];
-				updated = YES;
 			}
 			set.mutable = NO;
 		}

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1556,7 +1556,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 		else if ([value isKindOfClass: [COMutableArray class]])
 		{
 			COMutableArray *array = value;
-			const NSUInteger count = [array count];
+			const NSUInteger count = array.backing.count;
 
 			array.mutable = YES;
 			for (NSUInteger i=0; i<count; i++)

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1561,7 +1561,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 			array.mutable = YES;
 			for (NSUInteger i=0; i<count; i++)
 			{
-				if ([array referenceAtIndex: i] == object)
+				if ([[array referenceAtIndex: i] isEqual: object])
 				{
 					if (!updated)
 					{

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1493,7 +1493,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 			array.mutable = YES;
 			for (NSUInteger i=0; i<count; i++)
 			{
-				if (array[i] == object)
+				if ([array referenceAtIndex: i] == object)
 				{
 					[array replaceReferenceAtIndex: i withReference: replacement];
 				}

--- a/Core/COObjectGraphContext+Private.h
+++ b/Core/COObjectGraphContext+Private.h
@@ -81,6 +81,10 @@
 /**
  * This method is only exposed to be used internally by CoreObject.
  */
+- (void)replaceObject: (COObject *)anObject withObject: (COObject *)aReplacement;
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
 - (BOOL) isTrackingSpecificBranch;
 
 

--- a/Core/COObjectGraphContext.h
+++ b/Core/COObjectGraphContext.h
@@ -184,6 +184,7 @@ extern NSString * const COObjectGraphContextEndBatchChangeNotification;
     NSMutableSet *_insertedObjectUUIDs;
     NSMutableSet *_updatedObjectUUIDs;
     NSMutableDictionary *_updatedPropertiesByUUID;
+	BOOL _ignoresChangeTrackingNotifications;
 	/** How many commits have been done since last garbage collection */
 	uint64_t _numberOfCommitsSinceLastGC;
 }

--- a/Core/COObjectGraphContext.h
+++ b/Core/COObjectGraphContext.h
@@ -184,7 +184,6 @@ extern NSString * const COObjectGraphContextEndBatchChangeNotification;
     NSMutableSet *_insertedObjectUUIDs;
     NSMutableSet *_updatedObjectUUIDs;
     NSMutableDictionary *_updatedPropertiesByUUID;
-	BOOL _ignoresChangeTrackingNotifications;
 	/** How many commits have been done since last garbage collection */
 	uint64_t _numberOfCommitsSinceLastGC;
 }

--- a/Core/COObjectGraphContext.m
+++ b/Core/COObjectGraphContext.m
@@ -883,7 +883,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 		referringObjects = [[anObject incomingRelationshipCache] referringObjects];
 	}
 
-	_ignoresChangeTrackingNotifications = YES;
+	//_ignoresChangeTrackingNotifications = YES;
 	for (COObject *referrer in referringObjects)
 	{
 		/* The dead relationship cache tracks referring objects that exist 
@@ -896,7 +896,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 		[referrer replaceReferencesToObjectIdenticalTo: anObject
 											withObject: aReplacement];
 	}
-	_ignoresChangeTrackingNotifications = NO;
+	//_ignoresChangeTrackingNotifications = NO;
 }
 
 - (COItemGraph *)modifiedItemsSnapshot

--- a/Core/COObjectGraphContext.m
+++ b/Core/COObjectGraphContext.m
@@ -638,7 +638,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 
 - (void)markObjectAsUpdated: (COObject *)obj forProperty: (NSString *)aProperty
 {
-	if (_ignoresChangeTrackingNotifications)
+	if (ignoresChangeTrackingNotifications)
 		return;
 
 	ETUUID *uuid = obj.UUID;
@@ -852,6 +852,8 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 	return [deadRelationshipCache referringObjectsForPath: pathToUndeletedObject].setRepresentation;
 }
 
+static BOOL ignoresChangeTrackingNotifications = NO;
+
 /**
  * This method is called on every object graph containing one or more referring 
  * objects (the relationship sources) whose properties needs to be updated to 
@@ -883,20 +885,13 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 		referringObjects = [[anObject incomingRelationshipCache] referringObjects];
 	}
 
-	//_ignoresChangeTrackingNotifications = YES;
+	ignoresChangeTrackingNotifications = YES;
 	for (COObject *referrer in referringObjects)
 	{
-		/* The dead relationship cache tracks referring objects that exist 
-		   in the tracking branch and current branch, but the current branch 
-		   object graph won't be fixed. If both object graphs were changed,
-		   an exception would be raised at commit time. */
-		if (referrer.objectGraphContext == referrer.persistentRoot.currentBranch.objectGraphContext)
-			continue;
-
 		[referrer replaceReferencesToObjectIdenticalTo: anObject
 											withObject: aReplacement];
 	}
-	//_ignoresChangeTrackingNotifications = NO;
+	ignoresChangeTrackingNotifications = NO;
 }
 
 - (COItemGraph *)modifiedItemsSnapshot

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -443,8 +443,7 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 	/* Clear other pending changes */
 
-	[_branchesPendingDeletion removeAllObjects];
-	[_branchesPendingUndeletion removeAllObjects];
+	[self clearBranchesPendingDeletionAndUndeletion];
 
 	if (_metadataChanged)
     {
@@ -731,6 +730,10 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	}
 	
 	ETAssert([[self branchesPendingInsertion] isEmpty]);
+}
+
+- (void)clearBranchesPendingDeletionAndUndeletion
+{
 	[_branchesPendingDeletion removeAllObjects];
 	[_branchesPendingUndeletion removeAllObjects];
 }

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -322,6 +322,7 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	_currentBranchObjectGraph.branch = aBranch;
 	
 	[self reloadCurrentBranchObjectGraph];
+	// TODO: Update cross persistent root references
 }
 
 - (NSSet *)branches

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -188,6 +188,22 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	return [self descriptionWithOptions: options];
 }
 
+/**
+ * We don't need to update incoming cross persistent root references in this 
+ * method, since the root object UUID is stable in the history and the object 
+ * graph will constantly reuse the same root object instance once allocated, 
+ * even while navigating the history.
+ *
+ * When we unfault an object graph, we never have to fix other persistent root
+ * branches, since their outgoing references are always resolved at 
+ * deserialization time (unfaulting all object graphs required to resolve them). 
+ * This means a lazily unfaulted object graph is never referenced by an already 
+ * loaded object graph.
+ *
+ * On -setItemGraph:, the deserialization code will also automatically check
+ * which persistent roots or branches are deleted, and decide which outgoing
+ * references are dead or live accordingly.
+ */
 - (void) setCurrentBranchObjectGraphToRevisionUUID: (ETUUID *)aRevision
 								persistentRootUUID: (ETUUID*)aPersistentRoot
 {

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -359,6 +359,9 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	{
 		[_branchesPendingDeletion addObject: aBranch];
 	}
+	[self.editingContext updateCrossPersistentRootReferencesToPersistentRoot: aBranch.persistentRoot
+	                                                                  branch: aBranch
+	                                                               isDeleted: YES];
 }
 
 - (void)undeleteBranch: (COBranch *)aBranch
@@ -371,6 +374,9 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
     {
         [_branchesPendingUndeletion addObject: aBranch];
     }
+	[self.editingContext updateCrossPersistentRootReferencesToPersistentRoot: aBranch.persistentRoot
+	                                                                  branch: aBranch
+	                                                               isDeleted: NO];
 }
 
 #pragma mark Pending Changes -

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -30,9 +30,10 @@
 	@public
 	BOOL _mutable;
 	NSHashTable *_backing;
-	NSHashTable *_deadObjects;
+	NSHashTable *_deadReferences;
 }
-- (void)addDeadPath: (COPath *)aPath;
+- (void)addReference: (id)aReference;
+- (void)removeReference: (id)aReference;
 @end
 
 @interface COMutableArray : NSMutableArray <COPrimitiveCollection>
@@ -42,7 +43,8 @@
 	NSPointerArray *_backing;
 	NSMutableIndexSet *_deadIndexes;
 }
-- (void)addDeadPath: (COPath *)aPath;
+- (void)addReference: (id)aReference;
+- (void)replaceReferenceAtIndex: (NSUInteger)index withReference: (id)aReference;
 @end
 
 @interface COUnsafeRetainedMutableSet : COMutableSet
@@ -58,5 +60,5 @@
 	NSMutableDictionary *_backing;
 	NSMutableSet *_deadKeys;
 }
-- (void)setDeadPath: (COPath *)aPath forKey: (id <NSCopying>)aKey;
+- (void)setReference: (id)aReference forKey: (id <NSCopying>)aKey;
 @end

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -45,6 +45,9 @@
 	NSPointerArray *_backing;
 	NSMutableIndexSet *_deadIndexes;
 }
+
+@property (nonatomic, readonly) NSPointerArray *backing;
+
 - (id)referenceAtIndex: (NSUInteger)index;
 - (void)addReference: (id)aReference;
 - (void)replaceReferenceAtIndex: (NSUInteger)index withReference: (id)aReference;

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -34,6 +34,7 @@
 }
 - (void)addReference: (id)aReference;
 - (void)removeReference: (id)aReference;
+- (BOOL)containsReference: (id)aReference;
 @end
 
 @interface COMutableArray : NSMutableArray <COPrimitiveCollection>

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -44,6 +44,7 @@
 	NSPointerArray *_backing;
 	NSMutableIndexSet *_deadIndexes;
 }
+- (id)referenceAtIndex: (NSUInteger)index;
 - (void)addReference: (id)aReference;
 - (void)replaceReferenceAtIndex: (NSUInteger)index withReference: (id)aReference;
 @end
@@ -52,6 +53,11 @@
 @end
 
 @interface COUnsafeRetainedMutableArray : COMutableArray
+{
+	// TODO: Replace with custom acquire/relinquish functions to retain/release
+	// COPath references as necessary
+	NSMutableSet *_deadReferences;
+}
 @end
 
 @interface COMutableDictionary : NSMutableDictionary <COPrimitiveCollection>

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <EtoileFoundation/EtoileFoundation.h>
 
-@class COObject;
+@class COObject, COPath;
 
 @interface COWeakRef : NSObject
 {
@@ -30,7 +30,9 @@
 	@public
 	BOOL _mutable;
 	NSHashTable *_backing;
+	NSHashTable *_deadObjects;
 }
+- (void)addDeadPath: (COPath *)aPath;
 @end
 
 @interface COMutableArray : NSMutableArray <COPrimitiveCollection>
@@ -38,7 +40,9 @@
 @public
 	BOOL _mutable;
 	NSPointerArray *_backing;
+	NSMutableIndexSet *_deadIndexes;
 }
+- (void)addDeadPath: (COPath *)aPath;
 @end
 
 @interface COUnsafeRetainedMutableSet : COMutableSet
@@ -52,5 +56,7 @@
 	@public
 	BOOL _mutable;
 	NSMutableDictionary *_backing;
+	NSMutableSet *_deadKeys;
 }
+- (void)setDeadPath: (COPath *)aPath forKey: (id <NSCopying>)aKey;
 @end

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -23,6 +23,7 @@
 
 @protocol COPrimitiveCollection <NSObject>
 @property (nonatomic, getter=isMutable) BOOL mutable;
+@property (nonatomic, readonly) id <NSFastEnumeration> enumerableReferences;
 @end
 
 @interface COMutableSet : NSMutableSet <COPrimitiveCollection>

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -286,6 +286,13 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	return self;
 }
 
+- (id)copyWithZone: (NSZone *)zone
+{
+	COUnsafeRetainedMutableArray *newArray = [super copyWithZone: zone];
+	newArray->_deadReferences = [_deadReferences mutableCopyWithZone: zone];
+	return newArray;
+}
+
 - (void)addReference: (id)aReference
 {
 	[super addReference: aReference];

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -46,7 +46,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 @implementation COMutableArray
 
-@synthesize mutable = _mutable;
+@synthesize mutable = _mutable, backing = _backing;
 
 - (NSPointerArray *) makeBacking
 {

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -232,6 +232,11 @@ static inline void COThrowExceptionIfNotMutable(BOOL mutable)
 	[_backing removeObject: aReference];
 }
 
+- (BOOL)containsReference: (id)aReference
+{
+	return [_backing member: aReference] != nil;
+}
+
 - (NSHashTable *)aliveObjects
 {
 	NSHashTable *aliveObjects = [_backing mutableCopy];

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -109,10 +109,14 @@ static inline void COThrowExceptionIfNotMutable(BOOL mutable)
 	return [[self aliveIndexes] count];
 }
 
+- (NSUInteger)deadIndexCountBeforeIndex: (NSUInteger)index
+{
+	return [_deadIndexes countOfIndexesInRange: NSMakeRange(0, index - 1)];
+}
+
 - (id)objectAtIndex: (NSUInteger)index
 {
-	NSUInteger deadIndexCount = [_deadIndexes countOfIndexesInRange: NSMakeRange(0, index)];
-	return [_backing pointerAtIndex: index + deadIndexCount];
+	return [_backing pointerAtIndex: index + [self deadIndexCountBeforeIndex: index]];
 }
 
 - (void)addObject: (id)anObject
@@ -133,9 +137,8 @@ static inline void COThrowExceptionIfNotMutable(BOOL mutable)
     }
     else
     {
-		NSUInteger deadIndexCount = [_deadIndexes countOfIndexesInRange: NSMakeRange(0, index)];
         [_backing insertPointer: (__bridge void *)anObject
-		                atIndex: index + deadIndexCount];
+		                atIndex: index + [self deadIndexCountBeforeIndex: index]];
     }
 }
 
@@ -143,22 +146,19 @@ static inline void COThrowExceptionIfNotMutable(BOOL mutable)
 {
 	COThrowExceptionIfNotMutable(_mutable);
 	NSUInteger index = [self count] - 1;
-	NSUInteger deadIndexCount = [_deadIndexes countOfIndexesInRange: NSMakeRange(0, index)];
-	[self removeObjectAtIndex: index + deadIndexCount];
+	[self removeObjectAtIndex: index + [self deadIndexCountBeforeIndex: index]];
 }
 
 - (void)removeObjectAtIndex: (NSUInteger)index
 {
 	COThrowExceptionIfNotMutable(_mutable);
-	NSUInteger deadIndexCount = [_deadIndexes countOfIndexesInRange: NSMakeRange(0, index)];
-	[_backing removePointerAtIndex: index + deadIndexCount];
+	[_backing removePointerAtIndex: index + [self deadIndexCountBeforeIndex: index]];
 }
 
 - (void)replaceObjectAtIndex: (NSUInteger)index withObject: (id)anObject
 {
 	COThrowExceptionIfNotMutable(_mutable);
-	NSUInteger deadIndexCount = [_deadIndexes countOfIndexesInRange: NSMakeRange(0, index)];
-	[_backing replacePointerAtIndex: index + deadIndexCount
+	[_backing replacePointerAtIndex: index + [self deadIndexCountBeforeIndex: index]
 	                    withPointer: (__bridge void *)anObject];
 }
 

--- a/Core/CORelationshipCache.m
+++ b/Core/CORelationshipCache.m
@@ -13,6 +13,7 @@
 #import "COObject+Private.h"
 #import "COObjectGraphContext+Private.h"
 #import "COPersistentRoot.h"
+#import "COBranch.h"
 
 @interface COCachedRelationship : NSObject
 {
@@ -32,7 +33,7 @@
 @property (readwrite, nonatomic, copy) NSString *targetProperty;
 
 - (BOOL) isSourceObjectTrackingSpecificBranchForTargetObject: (COObject *)aTargetObject;
-
+- (BOOL)isSourceObjectBranchDeleted;
 
 @end
 
@@ -61,6 +62,11 @@
 		return NO;
 	}
 	return [_sourceObject.objectGraphContext isTrackingSpecificBranch];
+}
+
+- (BOOL)isSourceObjectBranchDeleted
+{
+	return _sourceObject.persistentRoot.deleted || _sourceObject.branch.deleted;
 }
 
 @end
@@ -96,6 +102,9 @@
 		   this corresponds to John (A) and Lucy (A) hiding the dotted incoming references from
 		   Group (B). */
 		if ([entry isSourceObjectTrackingSpecificBranchForTargetObject: _owner])
+			continue;
+
+		if ([entry isSourceObjectBranchDeleted])
 			continue;
 		
         if ([aProperty isEqualToString: entry->_targetProperty])

--- a/Core/COSerialization.m
+++ b/Core/COSerialization.m
@@ -703,14 +703,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 			                                              ofType: COTypePrimitivePart(type)
 			                                 propertyDescription: aPropertyDesc];
 			
-			if ([deserializedValue isKindOfClass: [COPath class]])
-			{
-				[resultCollection addDeadPath: deserializedValue];
-			}
-			else
-			{
-				[resultCollection addObject: deserializedValue];
-			}
+			[resultCollection addObject: deserializedValue];
 		}
 
 		// FIXME: Make read-only if needed
@@ -729,14 +722,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 			                                              ofType: COTypePrimitivePart(type)
 			                                 propertyDescription: aPropertyDesc];
 
-			if ([deserializedValue isKindOfClass: [COPath class]])
-			{
-				[resultCollection addDeadPath: deserializedValue];
-			}
-			else
-			{
-				[resultCollection addObject: deserializedValue];
-			}
+			[resultCollection addObject: deserializedValue];
 		}
 		
 		// FIXME: Make read-only if needed
@@ -838,13 +824,10 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 		BOOL isDeadCrossPersistentRootRef =
 			(result == nil && [value isKindOfClass: [COPath class]]);
 
-		if (isDeadCrossPersistentRootRef || isDeletedCrossPersistentRootRef)
-		{
-			result = COTypeIsMultivalued(type) ? value : nil;
-		}
+		result = (isDeadCrossPersistentRootRef || isDeletedCrossPersistentRootRef ? value : result);
 		
 		// TODO: We should be able to remove it since the value transformer
-		// should touch it
+		// shouldn't touch it
 		return result;
 	}
     else if (type == kCOTypeInt64)

--- a/Core/COSerialization.m
+++ b/Core/COSerialization.m
@@ -826,11 +826,11 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 		result = [self objectForSerializedReference: value
 										   ofType: type
 							  propertyDescription: aPropertyDesc];
-		
-		BOOL isDeletedCrossPersistentRootRef =
-			[(COObject *)result persistentRoot].isDeleted || [(COObject *)result branch].isDeleted;
-		BOOL isDeadCrossPersistentRootRef =
-			(result == nil && [value isKindOfClass: [COPath class]]);
+
+		BOOL isCrossPersistentRootRef = [value isKindOfClass: [COPath class]];
+		BOOL isDeletedCrossPersistentRootRef = isCrossPersistentRootRef
+			&& ([(COObject *)result persistentRoot].isDeleted || [(COObject *)result branch].isDeleted);
+		BOOL isDeadCrossPersistentRootRef = (result == nil && isCrossPersistentRootRef);
 
 		result = (isDeadCrossPersistentRootRef || isDeletedCrossPersistentRootRef ? value : result);
 		

--- a/Core/COSerialization.m
+++ b/Core/COSerialization.m
@@ -512,7 +512,7 @@ serialization. */
 	/* If no custom getter can be found, we access the stored value directly 
 	   (ivar and variable storage) */
 
-	return [self valueForStorageKey: [aPropertyDesc name]];
+	return [self serializableValueForStorageKey: [aPropertyDesc name]];
 }
 
 - (COItem *)storeItemWithUUID: (ETUUID *)aUUID

--- a/Core/COSerialization.m
+++ b/Core/COSerialization.m
@@ -659,15 +659,19 @@ Nil is returned when the value type is unsupported by CoreObject deserialization
 						  || COTypePrimitivePart(type) == kCOTypeCompositeReference);
 		/* Look up a inner object reference in the receiver persistent root */
 		object = [[self objectGraphContext] objectReferenceWithUUID: value];
+		ETAssert(object != nil);
 	}
 	else /* COPath */
 	{
 		NSParameterAssert(COTypePrimitivePart(type) == kCOTypeReference);
 		object = [[[self persistentRoot] parentContext] crossPersistentRootReferenceWithPath: (COPath *)value];
+		/* object may be nil for dead reference */
 	}
 
-	ETAssert(object != nil);
-	ETAssert([[object entityDescription] isKindOfEntity: [aPropertyDesc persistentType]]);
+	if (object != nil)
+	{
+		ETAssert([[object entityDescription] isKindOfEntity: [aPropertyDesc persistentType]]);
+	}
 	
 	return object;
 }

--- a/CoreObject.xcodeproj/project.pbxproj
+++ b/CoreObject.xcodeproj/project.pbxproj
@@ -111,6 +111,10 @@
 		60B1568D19B860C8006D5EEF /* COUndoTrackStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 663CE29317C07ED800E729F5 /* COUndoTrackStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60B1568E19B861BF006D5EEF /* COEditingContext+Debugging.h in Headers */ = {isa = PBXBuildFile; fileRef = 601FD94418893ED50002F957 /* COEditingContext+Debugging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60B1568F19B861D3006D5EEF /* COObjectGraphContext+Debugging.h in Headers */ = {isa = PBXBuildFile; fileRef = 66A00A18187DDB6A005CFE16 /* COObjectGraphContext+Debugging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60B58E681B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 60B58E661B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.h */; };
+		60B58E691B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 60B58E661B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.h */; };
+		60B58E6A1B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B58E671B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.m */; };
+		60B58E6B1B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B58E671B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.m */; };
 		60B84C081A6E6F5F00418128 /* COTrackViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 60B84C061A6E6F5F00418128 /* COTrackViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60B84C091A6E6F5F00418128 /* COTrackViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60B84C071A6E6F5F00418128 /* COTrackViewController.m */; };
 		60C81D0B195DA82200AEEC68 /* COClassToString.m in Sources */ = {isa = PBXBuildFile; fileRef = 60C81D0A195DA82200AEEC68 /* COClassToString.m */; };
@@ -1035,6 +1039,8 @@
 		60AD2F511B0A5BB000A9F473 /* TestPrimitiveCollection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestPrimitiveCollection.m; sourceTree = "<group>"; };
 		60B1D3F919791F8800ACAC9C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		60B1D3FB19791F9400ACAC9C /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.0.sdk/usr/lib/libsqlite3.dylib; sourceTree = DEVELOPER_DIR; };
+		60B58E661B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COCrossPersistentRootDeadRelationshipCache.h; path = Core/COCrossPersistentRootDeadRelationshipCache.h; sourceTree = "<group>"; };
+		60B58E671B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = COCrossPersistentRootDeadRelationshipCache.m; path = Core/COCrossPersistentRootDeadRelationshipCache.m; sourceTree = "<group>"; };
 		60B84C061A6E6F5F00418128 /* COTrackViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COTrackViewController.h; path = Extras/HistoryView/UIKit/COTrackViewController.h; sourceTree = SOURCE_ROOT; };
 		60B84C071A6E6F5F00418128 /* COTrackViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = COTrackViewController.m; path = Extras/HistoryView/UIKit/COTrackViewController.m; sourceTree = SOURCE_ROOT; };
 		60C81D0A195DA82200AEEC68 /* COClassToString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = COClassToString.m; sourceTree = "<group>"; };
@@ -1796,6 +1802,8 @@
 		66457FEE17E968F1003C51A8 /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				60B58E661B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.h */,
+				60B58E671B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.m */,
 				60EBC199184CA38200F751F5 /* COPrimitiveCollection.h */,
 				60EBC19A184CA38200F751F5 /* COPrimitiveCollection.m */,
 				6609485D1787A1160049468B /* CORelationshipCache.h */,
@@ -2489,6 +2497,7 @@
 				60E08D0619792FFA00D1B7AD /* COLibrary.h in Headers */,
 				60E08D5019792FFA00D1B7AD /* COObjectGraphContext+Private.h in Headers */,
 				60E08D0A19792FFA00D1B7AD /* COError.h in Headers */,
+				60B58E691B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.h in Headers */,
 				60E08D0919792FFA00D1B7AD /* COBranch.h in Headers */,
 				60E08D5319792FFA00D1B7AD /* COCommandSetPersistentRootMetadata.h in Headers */,
 				60E08D1519792FFA00D1B7AD /* CORelationshipCache.h in Headers */,
@@ -2548,6 +2557,7 @@
 				66BDC4B017B6ED27003B0EDA /* COPersistentRootInfo.h in Headers */,
 				66D96CB9178B717200D1553C /* COBinaryWriter.h in Headers */,
 				66D96CC0178B717200D1553C /* CORevisionInfo.h in Headers */,
+				60B58E681B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.h in Headers */,
 				66D96CC2178B717200D1553C /* COSearchResult.h in Headers */,
 				66D96CC4178B717200D1553C /* COSQLiteStore.h in Headers */,
 				66D96CC6178B717200D1553C /* COSQLiteStore+Attachments.h in Headers */,
@@ -3151,6 +3161,7 @@
 				60E08CB019792F4600D1B7AD /* COSearchResult.m in Sources */,
 				60882F1B197D50C000484033 /* COObjectToArchivedData.m in Sources */,
 				60E08CB119792F4600D1B7AD /* COSQLiteStore.m in Sources */,
+				60B58E6B1B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.m in Sources */,
 				60E08CAE19792F4600D1B7AD /* COItem+Binary.m in Sources */,
 				60E08CEF19792F4600D1B7AD /* COStoreSetCurrentRevision.m in Sources */,
 				60E08CED19792F4600D1B7AD /* COStoreSetCurrentBranch.m in Sources */,
@@ -3414,6 +3425,7 @@
 				66457FB817E8BFE5003C51A8 /* COStoreCreatePersistentRoot.m in Sources */,
 				66457FBA17E8BFE5003C51A8 /* COStoreDeleteBranch.m in Sources */,
 				66457FBC17E8BFE5003C51A8 /* COStoreDeletePersistentRoot.m in Sources */,
+				60B58E6A1B0BF1CD00A87D5F /* COCrossPersistentRootDeadRelationshipCache.m in Sources */,
 				663E9BA0182B85790083AC46 /* COSynchronizerPersistentRootInfoToClientMessage.m in Sources */,
 				66457FBE17E8BFE5003C51A8 /* COStoreSetBranchMetadata.m in Sources */,
 				66457FC017E8BFE5003C51A8 /* COStoreSetCurrentBranch.m in Sources */,

--- a/CoreObject.xcodeproj/project.pbxproj
+++ b/CoreObject.xcodeproj/project.pbxproj
@@ -106,6 +106,8 @@
 		609CB4D21A5E9384003E8052 /* COTopologicalSort.m in Sources */ = {isa = PBXBuildFile; fileRef = 609CB4CE1A5E9384003E8052 /* COTopologicalSort.m */; };
 		60AA7EB11A641FCD00897498 /* COSchemaMigrationDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 60FA55DE1A447A8600A2D8A7 /* COSchemaMigrationDriver.h */; };
 		60AA7EBC1A641FDE00897498 /* COSchemaMigrationDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FA55DF1A447A8600A2D8A7 /* COSchemaMigrationDriver.m */; };
+		60AD2F521B0A5BB000A9F473 /* TestPrimitiveCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AD2F511B0A5BB000A9F473 /* TestPrimitiveCollection.m */; };
+		60AD2F531B0A5BB000A9F473 /* TestPrimitiveCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AD2F511B0A5BB000A9F473 /* TestPrimitiveCollection.m */; };
 		60B1568D19B860C8006D5EEF /* COUndoTrackStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 663CE29317C07ED800E729F5 /* COUndoTrackStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60B1568E19B861BF006D5EEF /* COEditingContext+Debugging.h in Headers */ = {isa = PBXBuildFile; fileRef = 601FD94418893ED50002F957 /* COEditingContext+Debugging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60B1568F19B861D3006D5EEF /* COObjectGraphContext+Debugging.h in Headers */ = {isa = PBXBuildFile; fileRef = 66A00A18187DDB6A005CFE16 /* COObjectGraphContext+Debugging.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1030,6 +1032,7 @@
 		609CB4BE1A5D8380003E8052 /* COModelElementMove.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = COModelElementMove.m; path = SchemaMigration/COModelElementMove.m; sourceTree = SOURCE_ROOT; };
 		609CB4CD1A5E9384003E8052 /* COTopologicalSort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COTopologicalSort.h; path = Utilities/COTopologicalSort.h; sourceTree = "<group>"; };
 		609CB4CE1A5E9384003E8052 /* COTopologicalSort.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = COTopologicalSort.m; path = Utilities/COTopologicalSort.m; sourceTree = "<group>"; };
+		60AD2F511B0A5BB000A9F473 /* TestPrimitiveCollection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestPrimitiveCollection.m; sourceTree = "<group>"; };
 		60B1D3F919791F8800ACAC9C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		60B1D3FB19791F9400ACAC9C /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.0.sdk/usr/lib/libsqlite3.dylib; sourceTree = DEVELOPER_DIR; };
 		60B84C061A6E6F5F00418128 /* COTrackViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COTrackViewController.h; path = Extras/HistoryView/UIKit/COTrackViewController.h; sourceTree = SOURCE_ROOT; };
@@ -2126,6 +2129,7 @@
 				66E40D351836D08D00E5B4A7 /* TestObjectGraphContext.m */,
 				66E40D361836D08D00E5B4A7 /* TestObjectUpdate.m */,
 				66E40D371836D08D00E5B4A7 /* TestPersistentRoot.m */,
+				60AD2F511B0A5BB000A9F473 /* TestPrimitiveCollection.m */,
 				66E40D381836D08D00E5B4A7 /* TestRevisionNumber.m */,
 				6660B3951839522B009007FD /* TestSerialization.m */,
 			);
@@ -3238,6 +3242,7 @@
 				60F91EE0197D324B009F47D7 /* TestHistoryTrack.m in Sources */,
 				60F91EE4197D324B009F47D7 /* TestUndoTrack.m in Sources */,
 				60F91F31197D32E2009F47D7 /* UnivaluedAttributeModel.m in Sources */,
+				60AD2F531B0A5BB000A9F473 /* TestPrimitiveCollection.m in Sources */,
 				60F91F25197D32E2009F47D7 /* OrderedGroupNoOpposite.m in Sources */,
 				60F91EFC197D3282009F47D7 /* TestCrossPersistentRootReferences.m in Sources */,
 				60F91F04197D3282009F47D7 /* TestRevisionNumber.m in Sources */,
@@ -3497,6 +3502,7 @@
 				66E40D761836D08E00E5B4A7 /* TestHistoryTrack.m in Sources */,
 				66E451D917CC565200205679 /* Tag.m in Sources */,
 				66EEB2B7186D3CBA003695E6 /* TestItemGraph.m in Sources */,
+				60AD2F521B0A5BB000A9F473 /* TestPrimitiveCollection.m in Sources */,
 				66E40D6D1836D08D00E5B4A7 /* TestSQLiteStoreErrorHandling.m in Sources */,
 				66E40D741836D08E00E5B4A7 /* TestSynchronizerMultiUser.m in Sources */,
 				6610115B184D8B9E001A3E24 /* UnorderedGroupNoOpposite.m in Sources */,

--- a/Tests/Core/TestCrossPersistentRootReferences.m
+++ b/Tests/Core/TestCrossPersistentRootReferences.m
@@ -439,7 +439,6 @@
 									 error: NULL];
 
     // Finalized deletion, reference should be hidden
-    // FIXME: Currently failing with an assertion failure
     [self checkPersistentRootWithExistingAndNewContext: library1
                                                inBlock: ^(COEditingContext *testCtx, COPersistentRoot *testProot, COBranch *testBranch, BOOL isNewContext)
      {
@@ -585,8 +584,6 @@
     
     // Add photo2 inner item. Note that the photo1 cross-persistent-root reference is
     // still present in library1.contents, it's just hidden.
-    // FIXME: That is the part that's difficult to implement and not currently implemented.
-	// See comment in -[COObject updateOutgoingSerializedRelationshipCacheForProperty]
 	
     COObject *photo2 = [[library1 objectGraphContext] insertObjectWithEntityName: @"Anonymous.OutlineItem"];
     [photo2 setValue: @"photo2" forProperty: @"label"];
@@ -607,9 +604,8 @@
         COPersistentRoot *photo1ctx2 = [[ctx2 deletedPersistentRoots] anyObject];
         [photo1ctx2 setDeleted: NO];
         
-		// FIXME: Currently broken, see comment in -[COObject updateCrossPersistentRootReferences]
-        //UKFalse([[library1ctx2 objectGraphContext] hasChanges]);
-       // UKObjectsEqual(S(@"photo1", @"photo2"), [[library1ctx2 rootObject] valueForKeyPath: @"contents.label"]);
+        UKFalse([[library1ctx2 objectGraphContext] hasChanges]);
+        UKObjectsEqual(S(@"photo1", @"photo2"), [[library1ctx2 rootObject] valueForKeyPath: @"contents.label"]);
 	 }];
 }
 
@@ -639,6 +635,7 @@
 	
 	
 	// FIXME: Currently fails for the isNewContext==NO case
+	// Caused by https://github.com/etoile/CoreObject/issues/20
 #if 0
 	[self checkPersistentRootWithExistingAndNewContext: photo1
 											   inBlock: ^(COEditingContext *ctx2, COPersistentRoot *photo1ctx2, COBranch *testBranch, BOOL isNewContext)

--- a/Tests/Core/TestCrossPersistentRootReferences.m
+++ b/Tests/Core/TestCrossPersistentRootReferences.m
@@ -593,7 +593,7 @@
     photo1.deleted = YES;
     [ctx commit];
     
-    UKObjectsEqual(S(@"photo1"), [[library1 rootObject] valueForKeyPath: @"contents.label"]);
+    UKObjectsEqual(S(), [[library1 rootObject] valueForKeyPath: @"contents.label"]);
     
     // Add photo2 inner item. Note that the photo1 cross-persistent-root reference is
     // still present in library1.contents, it's just hidden.
@@ -604,7 +604,7 @@
     [photo2 setValue: @"photo2" forProperty: @"label"];
     [[library1 rootObject] addObject: photo2];
     
-    UKObjectsEqual(S(@"photo1", @"photo2"), [[library1 rootObject] valueForKeyPath: @"contents.label"]);
+    UKObjectsEqual(S(@"photo2"), [[library1 rootObject] valueForKeyPath: @"contents.label"]);
     
     [ctx commit];
     
@@ -612,7 +612,7 @@
 											  inBlock: ^(COEditingContext *ctx2, COPersistentRoot *library1ctx2, COBranch *testBranch, BOOL isNewContext)
 	 {
         UKFalse([[library1ctx2 objectGraphContext] hasChanges]);
-        UKObjectsEqual(S(@"photo1", @"photo2"), [[library1ctx2 rootObject] valueForKeyPath: @"contents.label"]);
+        UKObjectsEqual(S(@"photo2"), [[library1ctx2 rootObject] valueForKeyPath: @"contents.label"]);
         
         // Undelete photo1, which should restore the cross-root relationship
         
@@ -621,7 +621,7 @@
         
 		// FIXME: Currently broken, see comment in -[COObject updateCrossPersistentRootReferences]
         //UKFalse([[library1ctx2 objectGraphContext] hasChanges]);
-        UKObjectsEqual(S(@"photo1", @"photo2"), [[library1ctx2 rootObject] valueForKeyPath: @"contents.label"]);
+       // UKObjectsEqual(S(@"photo1", @"photo2"), [[library1ctx2 rootObject] valueForKeyPath: @"contents.label"]);
 	 }];
 }
 

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -1,0 +1,328 @@
+/*
+    Copyright (C) 2013 Quentin Mathe, Eric Wasylishen
+
+    Date:  April 2013
+    License:  MIT  (see COPYING)
+ */
+
+#import <UnitKit/UnitKit.h>
+#import <Foundation/Foundation.h>
+#import "TestCommon.h"
+
+@interface COMutableArray (TestPrimitiveCollection)
+@property (nonatomic, readonly) NSIndexSet *deadIndexes;
+@property (nonatomic, readonly) NSArray *deadReferences;
+@property (nonatomic, readonly) NSArray *allReferences;
+@end
+
+@implementation COMutableArray (TestPrimitiveCollection)
+
+- (NSIndexSet *)deadIndexes
+{
+	return _deadIndexes;
+}
+
+- (NSArray *)deadReferences
+{
+	return [_backing.allObjects objectsAtIndexes: _deadIndexes];
+}
+
+- (NSArray *)allReferences
+{
+	return _backing.allObjects;
+}
+
+@end
+
+@interface TestMutableArray : NSObject <UKTest>
+{
+	COMutableArray *array;
+	id alive1;
+	id alive2;
+	id alive3;
+	id dead1;
+	id dead2;
+	id dead3;
+	
+}
+
+@end
+
+@implementation TestMutableArray
+
+- (id)init
+{
+	SUPERINIT;
+	array = [COMutableArray new];
+	array.mutable = YES;
+	alive1 = @"alive1";
+	alive2 = @"alive2";
+	alive3 = @"alive3";
+	dead1 = [COPath pathWithPersistentRoot: [ETUUID UUID]];
+	dead2 = [COPath pathWithPersistentRoot: [ETUUID UUID]];
+	dead3 = [COPath pathWithPersistentRoot: [ETUUID UUID]];
+	return self;
+}
+
+- (void)testEmptyCollection
+{
+	UKIntsEqual(0, array.count);
+	UKFalse([array containsObject: @"something"]);
+}
+
+#pragma mark - Backing Operations
+
+- (void)testAliveReferenceAddition
+{
+	[array addReference: alive1];
+	
+	UKTrue(array.deadIndexes.isEmpty);
+	UKTrue(array.deadReferences.isEmpty);
+	UKIntsEqual(1, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+}
+
+- (void)testDeadReferenceAddition
+{
+	[array addReference: dead1];
+	
+	UKObjectsEqual(INDEXSET(0), array.deadIndexes);
+	UKObjectsEqual(A(dead1), array.deadReferences);
+	UKObjectsEqual(A(dead1), array.allReferences);
+	UKIntsEqual(0, array.count);
+	UKFalse([array containsObject: dead1]);
+	UKRaisesException([array objectAtIndex: 0]);
+}
+
+- (void)testDeadBeforeAliveReferenceAddition
+{
+	[array addReference: dead1];
+	[array addReference: alive1];
+
+	UKObjectsEqual(INDEXSET(0), array.deadIndexes);
+	UKObjectsEqual(A(dead1), array.deadReferences);
+	UKObjectsEqual(A(dead1, alive1), array.allReferences);
+	UKIntsEqual(1, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKRaisesException([array objectAtIndex: 1]);
+}
+
+- (void)testDeadAfterAliveReferenceAddition
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	
+	UKObjectsEqual(INDEXSET(1), array.deadIndexes);
+	UKObjectsEqual(A(dead1), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1), array.allReferences);
+	UKIntsEqual(1, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKRaisesException([array objectAtIndex: 1]);
+}
+
+- (void)testDeadAndAliveMixedReferenceAddition
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: dead2];
+	[array addReference: alive2];
+	[array addReference: dead3];
+
+	UKObjectsEqual(INDEXSET(1, 2, 4), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2, dead3), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, dead2, alive2, dead3), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 2]);
+}
+
+- (void)testDeadReferenceReplacement
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+
+	[array replaceReferenceAtIndex: 3 withReference: dead3];
+
+	UKObjectsEqual(INDEXSET(1, 3), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead3), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, alive2, dead3), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 2]);
+}
+
+- (void)testAliveReferenceReplacement
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	
+	[array replaceReferenceAtIndex: 2 withReference: alive3];
+	
+	UKObjectsEqual(INDEXSET(1, 3), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, alive3, dead2), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive3, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 2]);
+}
+
+#pragma mark - Alive Objects Operations
+
+- (void)testFirstObjectInsertion
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	
+	[array insertObject: alive3 atIndex: 0];
+	
+	UKObjectsEqual(INDEXSET(2, 4), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive3, alive1, dead1, alive2, dead2), array.allReferences);
+	UKIntsEqual(3, array.count);
+	UKObjectsEqual(alive3, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive1, [array objectAtIndex: 1]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 2]);
+	UKRaisesException([array objectAtIndex: 3]);
+}
+
+- (void)testMiddleObjectInsertion
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	
+	[array insertObject: alive3 atIndex: 1];
+	
+	UKObjectsEqual(INDEXSET(1, 4), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, alive3, alive2, dead2), array.allReferences);
+	UKIntsEqual(3, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive3, [array objectAtIndex: 1]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 2]);
+	UKRaisesException([array objectAtIndex: 3]);
+}
+
+- (void)testLastObjectInsertion
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	
+	[array insertObject: alive3 atIndex: 2];
+	
+	UKObjectsEqual(INDEXSET(1, 3), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, alive2, dead2, alive3), array.allReferences);
+	UKIntsEqual(3, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 1]);
+	UKObjectsEqual(alive3, [array objectAtIndex: 2]);
+	UKRaisesException([array objectAtIndex: 3]);
+}
+
+- (void)testFirstObjectRemoval
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	[array addReference: alive3];
+	
+	[array removeObjectAtIndex: 0];
+	
+	UKObjectsEqual(INDEXSET(0, 2), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(dead1, alive2, dead2, alive3), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive2, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive3, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 2]);
+}
+
+- (void)testMiddleObjectRemoval
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	[array addReference: alive3];
+
+	[array removeObjectAtIndex: 1];
+	
+	UKObjectsEqual(INDEXSET(1, 2), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, dead2, alive3), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive3, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 2]);
+}
+
+- (void)testLastObjectRemoval
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	[array addReference: alive3];
+
+	[array removeObjectAtIndex: 2];
+	
+	UKObjectsEqual(INDEXSET(1, 3), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, alive2, dead2), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 3]);
+}
+
+- (void)testFirstObjectReplacement
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	
+	[array replaceObjectAtIndex: 0 withObject: alive3];
+	
+	UKObjectsEqual(INDEXSET(1, 3), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive3, dead1, alive2, dead2), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive3, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 2]);
+}
+
+- (void)testLastObjectReplacement
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	
+	[array replaceObjectAtIndex: 1 withObject: alive3];
+	
+	UKObjectsEqual(INDEXSET(1, 3), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, alive3, dead2), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive3, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 2]);
+}
+
+@end

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -173,7 +173,7 @@
 	UKRaisesException([array objectAtIndex: 2]);
 }
 
-#pragma mark - Alive Objects Operations
+#pragma mark - Alive Objects Primitive Operations
 
 - (void)testFirstObjectInsertion
 {
@@ -323,6 +323,77 @@
 	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
 	UKObjectsEqual(alive3, [array objectAtIndex: 1]);
 	UKRaisesException([array objectAtIndex: 2]);
+}
+
+#pragma mark - Alive Objects Additional Operations
+
+/**
+ * -addObject: must call -insertObject:atIndex: with a valid index when the
+ * collection is empty.
+ */
+- (void)testFirstObjectAddition
+{
+	[array addObject: alive3];
+
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	
+	// Tests identical to -testFirstObjectInsertion
+	UKObjectsEqual(INDEXSET(2, 4), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive3, alive1, dead1, alive2, dead2), array.allReferences);
+	UKIntsEqual(3, array.count);
+	UKObjectsEqual(alive3, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive1, [array objectAtIndex: 1]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 2]);
+	UKRaisesException([array objectAtIndex: 3]);
+}
+
+- (void)testLastObjectAddition
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	
+	[array addObject: alive3];
+
+	// Tests identical to -testLastObjectInsertion
+	UKObjectsEqual(INDEXSET(1, 3), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, alive2, dead2, alive3), array.allReferences);
+	UKIntsEqual(3, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 1]);
+	UKObjectsEqual(alive3, [array objectAtIndex: 2]);
+	UKRaisesException([array objectAtIndex: 3]);
+}
+
+- (void)testRemoveLastObject
+{
+	[array addReference: alive1];
+	[array addReference: dead1];
+	[array addReference: alive2];
+	[array addReference: dead2];
+	[array addReference: alive3];
+	
+	[array removeLastObject];
+	
+	// Tests identical to -testLastObjectRemoval
+	UKObjectsEqual(INDEXSET(1, 3), array.deadIndexes);
+	UKObjectsEqual(A(dead1, dead2), array.deadReferences);
+	UKObjectsEqual(A(alive1, dead1, alive2, dead2), array.allReferences);
+	UKIntsEqual(2, array.count);
+	UKObjectsEqual(alive1, [array objectAtIndex: 0]);
+	UKObjectsEqual(alive2, [array objectAtIndex: 1]);
+	UKRaisesException([array objectAtIndex: 3]);
+}
+
+- (void)testRemoveLastObjectWhenEmpty
+{
+	UKDoesNotRaiseException([array removeLastObject]);
 }
 
 @end

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -194,11 +194,23 @@
 	                                           inBlock:
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
-		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OrderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OutlineItem *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(A(testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKTrue([testItem1 referringObjects].isEmpty);
+
+		OrderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+
+		UKObjectsEqual(A(testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -214,13 +226,25 @@
 	                                           inBlock:
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
-		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem1 =
+		OrderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OrderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testItem1 referringObjects]);
+
+		OutlineItem *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+		OutlineItem *testCurrentItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].currentBranch.rootObject;
+		
+		UKObjectsEqual(A(testItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -236,11 +260,23 @@
 											   inBlock:
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
-		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OrderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OutlineItem *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(A(testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKTrue([testItem1 referringObjects].isEmpty);
+		
+		OrderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+		
+		UKObjectsEqual(A(testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -259,18 +295,28 @@
 											   inBlock:
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
-		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem1 =
+		OrderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OrderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
-		UnorderedGroupNoOpposite *testOtherItem1 =
+		OrderedGroupNoOpposite *testOtherItem1 =
 			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKStringsEqual(@"other", testOtherItem1.label);
 		UKStringsEqual(@"current", testItem1.label);
 		UKObjectsEqual(A(testOtherItem1, testItem2), testGroup1.contents);
 		UKObjectsNotEqual(A(testItem1, testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
+		
+		OutlineItem *testCurrentOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+		
+		UKObjectsEqual(A(testOtherItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -290,11 +336,24 @@
 											   inBlock:
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
-		 UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		 UnorderedGroupNoOpposite *testItem2 =
+		OrderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OutlineItem *testOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].rootObject;
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 		 
-		 UKObjectsEqual(A(testItem2), testGroup1.contents);
+		UKObjectsEqual(A(testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKTrue([testOtherItem1 referringObjects].isEmpty);
+
+		OrderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testCurrentOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+
+		// FIXME: This test fails randomly every 5 run or so
+		//KObjectsEqual(A(testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -313,18 +372,30 @@
 											   inBlock:
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
-		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem1 =
+		OrderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OrderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
-		UnorderedGroupNoOpposite *testOtherItem1 =
+		OrderedGroupNoOpposite *testOtherItem1 =
 			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKStringsEqual(@"other", testOtherItem1.label);
 		UKStringsEqual(@"current", testItem1.label);
 		UKObjectsEqual(A(testOtherItem1, testItem2), testGroup1.contents);
 		UKObjectsNotEqual(A(testItem1, testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		// FIXME: This test fails randomly every 5 run or so
+		//UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
+
+		OutlineItem *testCurrentOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+		
+		// FIXME: This test fails randomly every 5 run or so
+		//UKObjectsEqual(A(testOtherItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
 

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -193,10 +193,7 @@
 		UnorderedGroupNoOpposite *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
-		// FIXME: The relationship cache needs some tweaking to keep track of
-		// dead relationships, since -referringObjects doesn't return testItem1
-		// in -[COObjectGraphContext replaceObject:withObject:].
-		//UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
 	}];
 }
 

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -213,11 +213,13 @@
 
 - (void)testRelationships
 {
+	OrderedGroupNoOpposite *currentGroup1 = group1.persistentRoot.currentBranch.rootObject;
+
 	UKObjectsEqual(A(item1, item2), group1.contents);
 	// Check that the relationship cache knows the inverse relationship,
 	// even though it is not used in the metamodel (non-public API)
-	UKObjectsEqual(S(group1, otherGroup1), [item1 referringObjects]);
-	UKObjectsEqual(S(group1, otherGroup1), [item2 referringObjects]);
+	UKObjectsEqual(S(group1, currentGroup1, otherGroup1), [item1 referringObjects]);
+	UKObjectsEqual(S(group1, currentGroup1, otherGroup1), [item2 referringObjects]);
 }
 
 - (void)testRelationshipsFromAndToCurrentBranches

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -213,7 +213,7 @@
 	UKTrue([currentItem2 referringObjects].isEmpty);
 }
 
-- (void)testPersistentRootDeletion
+- (void)testTargetPersistentRootDeletion
 {
 	item1.persistentRoot.deleted = YES;
 	[ctx commit];
@@ -228,7 +228,7 @@
 	}];
 }
 
-- (void)testPersistentRootUndeletion
+- (void)testTargetPersistentRootUndeletion
 {
 	item1.persistentRoot.deleted = YES;
 	[ctx commit];
@@ -255,7 +255,7 @@
 	}];
 }
 
-- (void)testPersistentRootDeletionForReferenceToSpecificBranch
+- (void)testTargetPersistentRootDeletionForReferenceToSpecificBranch
 {
 	group1.contents = A(otherItem1, item2);
 	[ctx commit];
@@ -273,7 +273,7 @@
 	}];
 }
 
-- (void)testPersistentRootUndeletionForReferenceToSpecificBranch
+- (void)testTargetPersistentRootUndeletionForReferenceToSpecificBranch
 {
 	group1.contents = A(otherItem1, item2);
 	[ctx commit];
@@ -299,9 +299,9 @@
 
 /**
  * The current branch cannot be deleted, so we cannot write a test method
- * -testBranchDeletion analog to -testPersistentRootDeletion
+ * -testTargetBranchDeletion analog to -testTargetPersistentRootDeletion
  */
-- (void)testBranchDeletionForReferenceToSpecificBranch
+- (void)testTargetBranchDeletionForReferenceToSpecificBranch
 {
 	group1.contents = A(otherItem1, item2);
 	[ctx commit];
@@ -319,7 +319,7 @@
 	}];
 }
 
-- (void)testBranchUndeletionForReferenceToSpecificBranch
+- (void)testTargetBranchUndeletionForReferenceToSpecificBranch
 {
 	group1.contents = A(otherItem1, item2);
 	[ctx commit];

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -141,6 +141,7 @@
 	OrderedGroupNoOpposite *group1;
 	OutlineItem *item1;
 	OutlineItem *item2;
+	OutlineItem *otherItem1;
 }
 
 @end
@@ -152,8 +153,12 @@
 	SUPERINIT;
 	group1 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupNoOpposite"].rootObject;
 	item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+	item1.label = @"current";
 	item2 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
 	group1.contents = A(item1, item2);
+	[ctx commit];
+	otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+	otherItem1.label = @"other";
 	[ctx commit];
 	return self;
 }
@@ -194,6 +199,36 @@
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
+	}];
+}
+
+- (void)testPersistentRootUndeletionForReferenceToSpecificBranch
+{
+	group1.contents = A(otherItem1, item2);
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+											   inBlock:
+		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
+		UnorderedGroupNoOpposite *testOtherItem1 =
+			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
+		UnorderedGroupNoOpposite *testItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
+
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(A(testOtherItem1, testItem2), testGroup1.contents);
+		UKObjectsNotEqual(A(testItem1, testItem2), testGroup1.contents);
 	}];
 }
 

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -246,7 +246,8 @@
 		// Bidirectional cross persistent root relationships are limited to the
 		// tracking branch, this means item1 in the non-tracking current branch
 		// doesn't appear in testCurrentGroup1.contents and doesn't refer to it
-		// with an inverse relationship.
+		// with an inverse relationship (-referringObjectsForPropertyInTarget:
+		// simulates it though).
 		// Bidirectional cross persistent root relationships are supported
 		// accross current branches, but materialized accross tracking branches
 		// in memory (they are not visible accross the current branches in memory).

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -202,6 +202,26 @@
 	}];
 }
 
+- (void)testPersistentRootDeletionForReferenceToSpecificBranch
+{
+	group1.contents = A(otherItem1, item2);
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+											   inBlock:
+		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
+
+		UKObjectsEqual(A(testItem2), testGroup1.contents);
+	}];
+}
+
 - (void)testPersistentRootUndeletionForReferenceToSpecificBranch
 {
 	group1.contents = A(otherItem1, item2);

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -276,6 +276,32 @@
 	}];
 }
 
+/**
+ * This is a regression test to cover cases where we are not iterating over
+ * references correctly in -[COObject replaceReferencesToObjectIdenticalTo:withObject:]
+ * (e.g. array.count rather array.backing.count).
+ */
+- (void)testTargetPersistentRootUndeletionWithEmptyGroup
+{
+	group1.contents = A(item1);
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem1), testGroup1.contents);
+		UKObjectsEqual(S(testGroup1, testOtherGroup1, testCurrentGroup1), [testItem1 referringObjects]);
+
+		UKObjectsEqual(A(testItem1), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
 - (void)testTargetPersistentRootDeletionForReferenceToSpecificBranch
 {
 	group1.contents = A(otherItem1, item2);

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -134,3 +134,70 @@
 }
 
 @end
+
+
+@interface TestCrossPersistentRootOrderedRelationship : EditingContextTestCase <UKTest>
+{
+	OrderedGroupNoOpposite *group1;
+	OutlineItem *item1;
+	OutlineItem *item2;
+}
+
+@end
+
+@implementation TestCrossPersistentRootOrderedRelationship
+
+- (id)init
+{
+	SUPERINIT;
+	group1 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupNoOpposite"].rootObject;
+	item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+	item2 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+	group1.contents = A(item1, item2);
+	[ctx commit];
+	return self;
+}
+
+- (void)testPersistentRootDeletion
+{
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+	                                           inBlock:
+		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
+
+		UKObjectsEqual(A(testItem2), testGroup1.contents);
+	}];
+}
+
+- (void)testPersistentRootUndeletion
+{
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+	                                           inBlock:
+		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
+		UnorderedGroupNoOpposite *testItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
+
+		// FIXME: The relationship cache needs some tweaking to keep track of
+		// dead relationships, since -referringObjects doesn't return testItem1
+		// in -[COObjectGraphContext replaceObject:withObject:].
+		//UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
+	}];
+}
+
+@end

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -351,8 +351,7 @@
 		OutlineItem *testCurrentOtherItem1 =
 			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
 
-		// FIXME: This test fails randomly every 5 run or so
-		//KObjectsEqual(A(testItem2), testCurrentGroup1.contents);
+		UKObjectsEqual(A(testItem2), testCurrentGroup1.contents);
 		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
@@ -387,14 +386,12 @@
 		UKObjectsNotEqual(A(testItem1, testItem2), testGroup1.contents);
 		// Check that the relationship cache knows the inverse relationship,
 		// even though it is not used in the metamodel (non-public API)
-		// FIXME: This test fails randomly every 5 run or so
-		//UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
 
 		OutlineItem *testCurrentOtherItem1 =
 			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
-		
-		// FIXME: This test fails randomly every 5 run or so
-		//UKObjectsEqual(A(testOtherItem1, testItem2), testCurrentGroup1.contents);
+
+		UKObjectsEqual(A(testOtherItem1, testItem2), testCurrentGroup1.contents);
 		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -138,8 +138,7 @@
 
 /**
  * For some general code comments that apply to all tests, see
- * -testTargetPersistentRootUndeletion, -testSourcePersistentRootUndeletion and
- * -testSourcePersistentRootUndeletionForReferenceToSpecificBranch.
+ * -testTargetPersistentRootUndeletion.
  *
  * For Relationship Source Deletion Tests, we test the referring objects that 
  * exist implicitly in the relationship cache, but are not exposed since the 

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -163,6 +163,28 @@
 	return self;
 }
 
+- (void)testRelationships
+{
+	UKObjectsEqual(A(item1, item2), group1.contents);
+	// Check that the relationship cache knows the inverse relationship,
+	// even though it is not used in the metamodel (non-public API)
+	UKObjectsEqual(S(group1), [item1 referringObjects]);
+	UKObjectsEqual(S(group1), [item2 referringObjects]);
+}
+
+- (void)testRelationshipsFromAndToCurrentBranches
+{
+	OrderedGroupNoOpposite *currentGroup1 = group1.persistentRoot.currentBranch.rootObject;
+	OutlineItem *currentItem1 = item1.persistentRoot.currentBranch.rootObject;
+	OutlineItem *currentItem2 = item2.persistentRoot.currentBranch.rootObject;
+	
+	UKObjectsEqual(A(item1, item2), currentGroup1.contents);
+	// Check that the relationship cache knows the inverse relationship,
+	// even though it is not used in the metamodel (non-public API)
+	UKTrue([currentItem1 referringObjects].isEmpty);
+	UKTrue([currentItem2 referringObjects].isEmpty);
+}
+
 - (void)testPersistentRootDeletion
 {
 	item1.persistentRoot.deleted = YES;

--- a/Tests/Relationship/TestOrderedRelationshipWithOpposite.m
+++ b/Tests/Relationship/TestOrderedRelationshipWithOpposite.m
@@ -103,3 +103,335 @@
 }
 
 @end
+
+
+/**
+ * For some general code comments that apply to all tests, see
+ * -testTargetPersistentRootUndeletion, -testSourcePersistentRootUndeletion and
+ * -testSourcePersistentRootUndeletionForReferenceToSpecificBranch.
+ */
+@interface TestCrossPersistentRootOrderedRelationshipWithOpposite : EditingContextTestCase <UKTest>
+{
+	OrderedGroupWithOpposite *group1;
+	OrderedGroupContent *item1;
+	OrderedGroupContent *item2;
+	OrderedGroupContent *otherItem1;
+	OrderedGroupWithOpposite *otherGroup1;
+}
+
+@end
+
+@implementation TestCrossPersistentRootOrderedRelationshipWithOpposite
+
+- (id)init
+{
+	SUPERINIT;
+
+	group1 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupWithOpposite"].rootObject;
+	item1 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupContent"].rootObject;
+	item1.label = @"current";
+	item2 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupContent"].rootObject;
+	group1.label = @"current";
+	group1.contents = A(item1, item2);
+	[ctx commit];
+
+	otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+	otherItem1.label = @"other";
+	otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+	otherGroup1.label = @"other";
+	[ctx commit];
+
+	return self;
+}
+
+#define CHECK_BLOCK_ARGS COEditingContext *testCtx, OrderedGroupWithOpposite *testGroup1, OrderedGroupContent *testItem1, OrderedGroupContent *testItem2, OrderedGroupContent *testOtherItem1, OrderedGroupWithOpposite *testOtherGroup1, OrderedGroupWithOpposite *testCurrentGroup1, OrderedGroupContent *testCurrentItem1, OrderedGroupContent *testCurrentItem2, OrderedGroupContent *testCurrentOtherItem1, OrderedGroupWithOpposite *testCurrentOtherGroup1, BOOL isNewContext
+
+- (void)checkPersistentRootsWithExistingAndNewContextInBlock: (void (^)(CHECK_BLOCK_ARGS))block
+{
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+											   inBlock:
+	 ^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		OrderedGroupWithOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OrderedGroupContent *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
+		OrderedGroupContent *testItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
+		OrderedGroupContent *testOtherItem1 =
+			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
+		OrderedGroupWithOpposite *testOtherGroup1 =
+			[testGroup1.persistentRoot branchForUUID: otherGroup1.branch.UUID].rootObject;
+		
+		OrderedGroupWithOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OrderedGroupContent *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+		OrderedGroupContent *testCurrentItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].currentBranch.rootObject;
+		OrderedGroupContent *testCurrentOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+		OrderedGroupWithOpposite *testCurrentOtherGroup1 =
+			[testCtx persistentRootForUUID: otherGroup1.persistentRoot.UUID].currentBranch.rootObject;
+	
+		block(testCtx, testGroup1, testItem1, testItem2, testOtherItem1, testOtherGroup1, testCurrentGroup1, testCurrentItem1, testCurrentItem2, testCurrentOtherItem1, testCurrentOtherGroup1, isNewContext);
+	}];
+}
+
+#pragma mark - Relationship Target Deletion Tests
+
+- (void)testTargetPersistentRootDeletion
+{
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem2), testGroup1.contents);
+		UKTrue(testItem1.parentGroups.isEmpty);
+
+		UKObjectsEqual(A(testItem2), testCurrentGroup1.contents);
+		UKTrue(testCurrentItem1.parentGroups.isEmpty);
+	}];
+}
+
+- (void)testTargetPersistentRootUndeletion
+{
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testItem1.parentGroups);
+
+		// Bidirectional cross persistent root relationships are limited to the
+		// tracking branch, this means item1 in the non-tracking current branch
+		// doesn't appear in testCurrentGroup1.contents and doesn't refer to it
+		// with an inverse relationship (-referringObjectsForPropertyInTarget:
+		// simulates it though).
+		// Bidirectional cross persistent root relationships are supported
+		// accross current branches, but materialized accross tracking branches
+		// in memory (they are not visible accross the current branches in memory).
+		UKObjectsEqual(A(testItem1, testItem2), testCurrentGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parentGroups);
+	}];
+}
+
+- (void)testTargetPersistentRootDeletionForReferenceToSpecificBranch
+{
+	group1.contents = A(otherItem1, item2);
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem2), testGroup1.contents);
+		UKTrue(testItem1.parentGroups.isEmpty);
+		
+		UKObjectsEqual(A(testItem2), testCurrentGroup1.contents);
+		UKTrue(testCurrentItem1.parentGroups.isEmpty);
+	}];
+}
+
+- (void)testTargetPersistentRootUndeletionForReferenceToSpecificBranch
+{
+	group1.contents = A(otherItem1, item2);
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(A(testOtherItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testOtherItem1.parentGroups);
+		
+		UKObjectsEqual(A(testOtherItem1, testItem2), testCurrentGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testOtherItem1.parentGroups);
+	}];
+}
+
+/**
+ * The current branch cannot be deleted, so we cannot write a test method
+ * -testTargetBranchDeletion analog to -testTargetPersistentRootDeletion
+ */
+- (void)testTargetBranchDeletionForReferenceToSpecificBranch
+{
+	group1.contents = A(otherItem1, item2);
+	[ctx commit];
+	
+	otherItem1.branch.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem2), testGroup1.contents);
+		UKTrue(testOtherItem1.parentGroups.isEmpty);
+
+		UKObjectsEqual(A(testItem2), testCurrentGroup1.contents);
+		UKTrue(testCurrentOtherItem1.parentGroups.isEmpty);
+
+	}];
+}
+
+- (void)testTargetBranchUndeletionForReferenceToSpecificBranch
+{
+	group1.contents = A(otherItem1, item2);
+	[ctx commit];
+	
+	otherItem1.branch.deleted = YES;
+	[ctx commit];
+
+	otherItem1.branch.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(A(testOtherItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testOtherItem1.parentGroups);
+
+		UKObjectsEqual(A(testOtherItem1, testItem2), testCurrentGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testOtherItem1.parentGroups);
+	}];
+}
+
+
+#pragma mark - Relationship Source Deletion Tests
+
+- (void)testSourcePersistentRootDeletion
+{
+	group1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
+		UKTrue(testItem1.parentGroups.isEmpty);
+
+		UKObjectsEqual(A(testItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue(testCurrentItem1.parentGroups.isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootUndeletion
+{
+	group1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	group1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
+		// testCurrentGroup1 and testOtherGroup1 present in -referringObjects are hidden by -referringObjectsForPropertyInTarget:
+		UKObjectsEqual(S(testGroup1), testItem1.parentGroups);
+		 
+		UKObjectsEqual(A(testItem1, testItem2), testCurrentGroup1.contents);
+		// testGroup1 missing from -referringObjects is added by -referringObjectsForPropertyInTarget:
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parentGroups);
+	}];
+}
+
+- (void)testSourcePersistentRootDeletionForReferenceToSpecificBranch
+{
+	otherGroup1.contents = A(item1, item2);
+	[ctx commit];
+
+	otherGroup1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem1, testItem2), testOtherGroup1.contents);
+		UKTrue(testItem1.parentGroups.isEmpty);
+		
+		UKObjectsEqual(A(testItem1, testItem2), testCurrentOtherGroup1.contents);
+		UKTrue(testCurrentItem1.parentGroups.isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootUndeletionForReferenceToSpecificBranch
+{
+	otherGroup1.contents = A(item1, item2);
+	[ctx commit];
+
+	otherGroup1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	otherGroup1.persistentRoot.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherGroup1.label);
+		UKStringsEqual(@"current", testGroup1.label);
+		UKObjectsEqual(A(testItem1, testItem2), testOtherGroup1.contents);
+		// Bidirectional inverse multivalued relationship always point to a
+		// single source object owned by the tracking branch, even when the
+		// relationship source object exist in multiple branches.
+		// For a parent-to-child relationship, reporting every branch source
+		// object as a distinct parent doesn't make sense, since conceptually
+		// they are all the same parent from the child viewpoint.
+		UKObjectsEqual(S(testGroup1), testItem1.parentGroups);
+		
+		UKObjectsEqual(A(testItem1, testItem2), testCurrentOtherGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parentGroups);
+	}];
+}
+
+- (void)testSourceBranchDeletionForReferenceToSpecificBranch
+{
+	otherGroup1.contents = A(item1, item2);
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = YES;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(A(testItem1, testItem2), testOtherGroup1.contents);
+		// The tracking branch is not deleted, so testItem1 parent is untouched,
+		// see comment in -testSourcePersistentRootUndeletionForReferenceToSpecificBranch
+		UKObjectsEqual(S(testGroup1), testItem1.parentGroups);
+
+		UKObjectsEqual(A(testItem1, testItem2), testCurrentGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parentGroups);
+	}];
+}
+
+- (void)testSourceBranchUndeletionForReferenceToSpecificBranch
+{
+	otherGroup1.contents = A(item1, item2);
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = YES;
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(A(testItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testItem1.parentGroups);
+
+		UKObjectsEqual(A(testItem1, testItem2), testCurrentGroup1.contents);
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parentGroups);
+	}];
+}
+
+@end

--- a/Tests/Relationship/TestUnivaluedRelationship.m
+++ b/Tests/Relationship/TestUnivaluedRelationship.m
@@ -112,3 +112,343 @@
 }
 
 @end
+
+/**
+ * For some general code comments that apply to all tests, see
+ * -testTargetPersistentRootUndeletion, -testSourcePersistentRootUndeletion and
+ * -testSourcePersistentRootUndeletionForReferenceToSpecificBranch.
+ *
+ * For Relationship Source Deletion Tests, we test the referring objects that 
+ * exist implicitly in the relationship cache, but are not exposed since the 
+ * relationship is unidirectional.
+ */
+@interface TestCrossPersistentRootUnivaluedRelationship : EditingContextTestCase <UKTest>
+{
+	UnivaluedGroupNoOpposite *group1;
+	OutlineItem *item1;
+	OutlineItem *otherItem1;
+	UnivaluedGroupNoOpposite *otherGroup1;
+}
+
+@end
+
+@implementation TestCrossPersistentRootUnivaluedRelationship
+
+- (id)init
+{
+	SUPERINIT;
+
+	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupNoOpposite"].rootObject;
+	item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+	item1.label = @"current";
+	group1.label = @"current";
+	group1.content = item1;
+	[ctx commit];
+
+	otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+	otherItem1.label = @"other";
+	otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+	otherGroup1.label = @"other";
+	[ctx commit];
+
+	return self;
+}
+
+#define CHECK_BLOCK_ARGS COEditingContext *testCtx, UnivaluedGroupNoOpposite *testGroup1, OutlineItem *testItem1, OutlineItem *testOtherItem1, UnivaluedGroupNoOpposite *testOtherGroup1, UnivaluedGroupNoOpposite *testCurrentGroup1, OutlineItem *testCurrentItem1, OutlineItem *testCurrentOtherItem1, UnivaluedGroupNoOpposite *testCurrentOtherGroup1, BOOL isNewContext
+
+- (void)checkPersistentRootsWithExistingAndNewContextInBlock: (void (^)(CHECK_BLOCK_ARGS))block
+{
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+											   inBlock:
+	 ^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		UnivaluedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OutlineItem *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
+		OutlineItem *testOtherItem1 =
+			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
+		UnivaluedGroupNoOpposite *testOtherGroup1 =
+			[testGroup1.persistentRoot branchForUUID: otherGroup1.branch.UUID].rootObject;
+
+		UnivaluedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+		OutlineItem *testCurrentOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+		UnivaluedGroupNoOpposite *testCurrentOtherGroup1 =
+			[testCtx persistentRootForUUID: otherGroup1.persistentRoot.UUID].currentBranch.rootObject;
+
+		block(testCtx, testGroup1, testItem1, testOtherItem1, testOtherGroup1, testCurrentGroup1, testCurrentItem1, testCurrentOtherItem1, testCurrentOtherGroup1, isNewContext);
+	}];
+}
+
+- (void)testRelationships
+{
+	UnivaluedGroupNoOpposite *currentGroup1 = group1.persistentRoot.currentBranch.rootObject;
+
+	UKObjectsEqual(item1, group1.content);
+	// Check that the relationship cache knows the inverse relationship,
+	// even though it is not used in the metamodel (non-public API)
+	UKObjectsEqual(S(group1, currentGroup1, otherGroup1), [item1 referringObjects]);
+}
+
+- (void)testRelationshipsFromAndToCurrentBranches
+{
+	UnivaluedGroupNoOpposite *currentGroup1 = group1.persistentRoot.currentBranch.rootObject;
+	OutlineItem *currentItem1 = item1.persistentRoot.currentBranch.rootObject;
+	
+	UKObjectsEqual(item1, currentGroup1.content);
+	// Check that the relationship cache knows the inverse relationship,
+	// even though it is not used in the metamodel (non-public API)
+	UKTrue([currentItem1 referringObjects].isEmpty);
+}
+
+#pragma mark - Relationship Target Deletion Tests
+
+- (void)testTargetPersistentRootDeletion
+{
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKNil(testGroup1.content);
+		UKTrue([testItem1 referringObjects].isEmpty);
+
+		UKNil(testCurrentGroup1.content);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testTargetPersistentRootUndeletion
+{
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(testItem1, testGroup1.content);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1), [testItem1 referringObjects]);
+
+		// Bidirectional cross persistent root relationships are limited to the
+		// tracking branch, this means item1 in the non-tracking current branch
+		// doesn't appear in testCurrentGroup1.contents and doesn't refer to it
+		// with an inverse relationship (-referringObjectsForPropertyInTarget:
+		// simulates it though).
+		// Bidirectional cross persistent root relationships are supported
+		// accross current branches, but materialized accross tracking branches
+		// in memory (they are not visible accross the current branches in memory).
+		UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testTargetPersistentRootDeletionForReferenceToSpecificBranch
+{
+	group1.content = otherItem1;
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKNil(testGroup1.content);
+		UKTrue([testItem1 referringObjects].isEmpty);
+		
+		UKNil(testCurrentGroup1.content);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testTargetPersistentRootUndeletionForReferenceToSpecificBranch
+{
+	group1.content = otherItem1;
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(testOtherItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
+		
+		UKObjectsEqual(testOtherItem1, testCurrentGroup1.content);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	}];
+}
+
+/**
+ * The current branch cannot be deleted, so we cannot write a test method
+ * -testTargetBranchDeletion analog to -testTargetPersistentRootDeletion
+ */
+- (void)testTargetBranchDeletionForReferenceToSpecificBranch
+{
+	group1.content = otherItem1;
+	[ctx commit];
+	
+	otherItem1.branch.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKNil(testGroup1.content);
+		UKTrue([testOtherItem1 referringObjects].isEmpty);
+
+		UKNil(testCurrentGroup1.content);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testTargetBranchUndeletionForReferenceToSpecificBranch
+{
+	group1.content = otherItem1;
+	[ctx commit];
+	
+	otherItem1.branch.deleted = YES;
+	[ctx commit];
+
+	otherItem1.branch.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(testOtherItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
+
+		UKObjectsEqual(testOtherItem1, testCurrentGroup1.content);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	}];
+}
+
+#pragma mark - Relationship Source Deletion Tests
+
+- (void)testSourcePersistentRootDeletion
+{
+	group1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(testItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1), [testItem1 referringObjects]);
+
+		UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootUndeletion
+{
+	group1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	group1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(testItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1), [testItem1 referringObjects]);
+		 
+		UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootDeletionForReferenceToSpecificBranch
+{
+	otherGroup1.content = item1;
+	[ctx commit];
+
+	otherGroup1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(testItem1, testOtherGroup1.content);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
+		
+		UKObjectsEqual(testItem1, testCurrentOtherGroup1.content);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootUndeletionForReferenceToSpecificBranch
+{
+	otherGroup1.content = item1;
+	[ctx commit];
+
+	otherGroup1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	otherGroup1.persistentRoot.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherGroup1.label);
+		UKStringsEqual(@"current", testGroup1.label);
+		UKObjectsEqual(testItem1, testOtherGroup1.content);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
+		
+		UKObjectsEqual(testItem1, testCurrentOtherGroup1.content);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testSourceBranchDeletionForReferenceToSpecificBranch
+{
+	otherGroup1.content = item1;
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = YES;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		 UKObjectsEqual(testItem1, testOtherGroup1.content);
+		 UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
+		 
+		 UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		 UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testSourceBranchUndeletionForReferenceToSpecificBranch
+{
+	otherGroup1.content = item1;
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = YES;
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(testItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
+
+		UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	}];
+}
+
+@end

--- a/Tests/Relationship/TestUnivaluedRelationship.m
+++ b/Tests/Relationship/TestUnivaluedRelationship.m
@@ -115,8 +115,7 @@
 
 /**
  * For some general code comments that apply to all tests, see
- * -testTargetPersistentRootUndeletion, -testSourcePersistentRootUndeletion and
- * -testSourcePersistentRootUndeletionForReferenceToSpecificBranch.
+ * -testTargetPersistentRootUndeletionh.
  *
  * For Relationship Source Deletion Tests, we test the referring objects that 
  * exist implicitly in the relationship cache, but are not exposed since the 

--- a/Tests/Relationship/TestUnivaluedRelationshipWithOpposite.m
+++ b/Tests/Relationship/TestUnivaluedRelationshipWithOpposite.m
@@ -79,3 +79,326 @@
 }
 
 @end
+
+/**
+ * For some general code comments that apply to all tests, see
+ * -testTargetPersistentRootUndeletion, -testSourcePersistentRootUndeletion and
+ * -testSourcePersistentRootUndeletionForReferenceToSpecificBranch.
+ */
+@interface TestCrossPersistentRootUnivaluedRelationshipWithOpposite : EditingContextTestCase <UKTest>
+{
+	UnivaluedGroupWithOpposite *group1;
+	UnivaluedGroupContent *item1;
+	UnivaluedGroupContent *otherItem1;
+	UnivaluedGroupWithOpposite *otherGroup1;
+}
+
+@end
+
+@implementation TestCrossPersistentRootUnivaluedRelationshipWithOpposite
+
+- (id)init
+{
+	SUPERINIT;
+
+	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupWithOpposite"].rootObject;
+	item1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupContent"].rootObject;
+	item1.label = @"current";
+	group1.label = @"current";
+	group1.content = item1;
+	[ctx commit];
+
+	otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+	otherItem1.label = @"other";
+	otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+	otherGroup1.label = @"other";
+	[ctx commit];
+
+	return self;
+}
+
+#define CHECK_BLOCK_ARGS COEditingContext *testCtx, UnivaluedGroupWithOpposite *testGroup1, UnivaluedGroupContent *testItem1, UnivaluedGroupContent *testOtherItem1, UnivaluedGroupWithOpposite *testOtherGroup1, UnivaluedGroupWithOpposite *testCurrentGroup1, UnivaluedGroupContent *testCurrentItem1, UnivaluedGroupContent *testCurrentOtherItem1, UnivaluedGroupWithOpposite *testCurrentOtherGroup1, BOOL isNewContext
+
+- (void)checkPersistentRootsWithExistingAndNewContextInBlock: (void (^)(CHECK_BLOCK_ARGS))block
+{
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+											   inBlock:
+	 ^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		UnivaluedGroupWithOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnivaluedGroupContent *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
+		UnivaluedGroupContent *testOtherItem1 =
+			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
+		UnivaluedGroupWithOpposite *testOtherGroup1 =
+			[testGroup1.persistentRoot branchForUUID: otherGroup1.branch.UUID].rootObject;
+
+		UnivaluedGroupWithOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		UnivaluedGroupContent *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+		UnivaluedGroupContent *testCurrentOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+		UnivaluedGroupWithOpposite *testCurrentOtherGroup1 =
+			[testCtx persistentRootForUUID: otherGroup1.persistentRoot.UUID].currentBranch.rootObject;
+
+		block(testCtx, testGroup1, testItem1, testOtherItem1, testOtherGroup1, testCurrentGroup1, testCurrentItem1, testCurrentOtherItem1, testCurrentOtherGroup1, isNewContext);
+	}];
+}
+
+#pragma mark - Relationship Target Deletion Tests
+
+- (void)testTargetPersistentRootDeletion
+{
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKNil(testGroup1.content);
+		UKTrue(testItem1.parents.isEmpty);
+
+		UKNil(testCurrentGroup1.content);
+		UKTrue(testCurrentItem1.parents.isEmpty);
+	}];
+}
+
+- (void)testTargetPersistentRootUndeletion
+{
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(testItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1), testItem1.parents);
+
+		// Bidirectional cross persistent root relationships are limited to the
+		// tracking branch, this means item1 in the non-tracking current branch
+		// doesn't appear in testCurrentGroup1.contents and doesn't refer to it
+		// with an inverse relationship (-referringObjectsForPropertyInTarget:
+		// simulates it though).
+		// Bidirectional cross persistent root relationships are supported
+		// accross current branches, but materialized accross tracking branches
+		// in memory (they are not visible accross the current branches in memory).
+		UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parents);
+	}];
+}
+
+- (void)testTargetPersistentRootDeletionForReferenceToSpecificBranch
+{
+	group1.content = otherItem1;
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKNil(testGroup1.content);
+		UKTrue(testItem1.parents.isEmpty);
+		
+		UKNil(testCurrentGroup1.content);
+		UKTrue(testCurrentItem1.parents.isEmpty);
+	}];
+}
+
+- (void)testTargetPersistentRootUndeletionForReferenceToSpecificBranch
+{
+	group1.content = otherItem1;
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	item1.persistentRoot.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(testOtherItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1), testOtherItem1.parents);
+		
+		UKObjectsEqual(testOtherItem1, testCurrentGroup1.content);
+		UKTrue(testCurrentOtherItem1.parents.isEmpty);
+	}];
+}
+
+/**
+ * The current branch cannot be deleted, so we cannot write a test method
+ * -testTargetBranchDeletion analog to -testTargetPersistentRootDeletion
+ */
+- (void)testTargetBranchDeletionForReferenceToSpecificBranch
+{
+	group1.content = otherItem1;
+	[ctx commit];
+	
+	otherItem1.branch.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKNil(testGroup1.content);
+		UKTrue(testOtherItem1.parents.isEmpty);
+
+		UKNil(testCurrentGroup1.content);
+		UKTrue(testCurrentOtherItem1.parents.isEmpty);
+	}];
+}
+
+- (void)testTargetBranchUndeletionForReferenceToSpecificBranch
+{
+	group1.content = otherItem1;
+	[ctx commit];
+	
+	otherItem1.branch.deleted = YES;
+	[ctx commit];
+
+	otherItem1.branch.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(testOtherItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1), testOtherItem1.parents);
+
+		UKObjectsEqual(testOtherItem1, testCurrentGroup1.content);
+		UKTrue(testCurrentOtherItem1.parents.isEmpty);
+	}];
+}
+
+#pragma mark - Relationship Source Deletion Tests
+
+- (void)testSourcePersistentRootDeletion
+{
+	group1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(testItem1, testGroup1.content);
+		UKTrue(testItem1.parents.isEmpty);
+
+		UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		UKTrue(testCurrentItem1.parents.isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootUndeletion
+{
+	group1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	group1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(testItem1, testGroup1.content);
+		// testCurrentGroup1 and testOtherGroup1 present in -referringObjects are hidden by -referringObjectsForPropertyInTarget:
+		UKObjectsEqual(S(testGroup1), testItem1.parents);
+		 
+		UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		// testGroup1 missing from -referringObjects is added by -referringObjectsForPropertyInTarget:
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parents);
+	}];
+}
+
+- (void)testSourcePersistentRootDeletionForReferenceToSpecificBranch
+{
+	otherGroup1.content = item1;
+	[ctx commit];
+
+	otherGroup1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(testItem1, testOtherGroup1.content);
+		UKTrue(testItem1.parents.isEmpty);
+		
+		UKObjectsEqual(testItem1, testCurrentOtherGroup1.content);
+		UKTrue(testCurrentItem1.parents.isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootUndeletionForReferenceToSpecificBranch
+{
+	otherGroup1.content = item1;
+	[ctx commit];
+
+	otherGroup1.persistentRoot.deleted = YES;
+	[ctx commit];
+	
+	otherGroup1.persistentRoot.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherGroup1.label);
+		UKStringsEqual(@"current", testGroup1.label);
+		UKObjectsEqual(testItem1, testOtherGroup1.content);
+		// Bidirectional inverse multivalued relationship always point to a
+		// single source object owned by the tracking branch, even when the
+		// relationship source object exist in multiple branches.
+		// For a parent-to-child relationship, reporting every branch source
+		// object as a distinct parent doesn't make sense, since conceptually
+		// they are all the same parent from the child viewpoint.
+		UKObjectsEqual(S(testGroup1), testItem1.parents);
+		
+		UKObjectsEqual(testItem1, testCurrentOtherGroup1.content);
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parents);
+	}];
+}
+
+- (void)testSourceBranchDeletionForReferenceToSpecificBranch
+{
+	otherGroup1.content = item1;
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = YES;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		 UKObjectsEqual(testItem1, testOtherGroup1.content);
+		// The tracking branch is not deleted, so testItem1 parent is untouched,
+		// see comment in -testSourcePersistentRootUndeletionForReferenceToSpecificBranch
+		 UKObjectsEqual(S(testGroup1), testItem1.parents);
+		 
+		 UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		 UKObjectsEqual(S(testGroup1), testCurrentItem1.parents);
+	}];
+}
+
+- (void)testSourceBranchUndeletionForReferenceToSpecificBranch
+{
+	otherGroup1.content = item1;
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = YES;
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(testItem1, testGroup1.content);
+		UKObjectsEqual(S(testGroup1), testItem1.parents);
+
+		UKObjectsEqual(testItem1, testCurrentGroup1.content);
+		UKObjectsEqual(S(testGroup1), testCurrentItem1.parents);
+	}];
+}
+
+@end

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -143,6 +143,28 @@
 	return self;
 }
 
+- (void)testRelationships
+{
+	UKObjectsEqual(S(item1, item2), group1.contents);
+	// Check that the relationship cache knows the inverse relationship,
+	// even though it is not used in the metamodel (non-public API)
+	UKObjectsEqual(S(group1), [item1 referringObjects]);
+	UKObjectsEqual(S(group1), [item2 referringObjects]);
+}
+
+- (void)testRelationshipsFromAndToCurrentBranches
+{
+	UnorderedGroupNoOpposite *currentGroup1 = group1.persistentRoot.currentBranch.rootObject;
+	OutlineItem *currentItem1 = item1.persistentRoot.currentBranch.rootObject;
+	OutlineItem *currentItem2 = item2.persistentRoot.currentBranch.rootObject;
+	
+	UKObjectsEqual(S(item1, item2), currentGroup1.contents);
+	// Check that the relationship cache knows the inverse relationship,
+	// even though it is not used in the metamodel (non-public API)
+	UKTrue([currentItem1 referringObjects].isEmpty);
+	UKTrue([currentItem2 referringObjects].isEmpty);
+}
+
 - (void)testPersistentRootDeletion
 {
 	item1.persistentRoot.deleted = YES;

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -230,7 +230,8 @@
 		// Bidirectional cross persistent root relationships are limited to the
 		// tracking branch, this means item1 in the non-tracking current branch
 		// doesn't appear in testCurrentGroup1.contents and doesn't refer to it
-		// with an inverse relationship.
+		// with an inverse relationship (-referringObjectsForPropertyInTarget:
+		// simulates it though).
 		// Bidirectional cross persistent root relationships are supported
 		// accross current branches, but materialized accross tracking branches
 		// in memory (they are not visible accross the current branches in memory).
@@ -324,6 +325,39 @@
 
 		UKObjectsEqual(S(testOtherItem1, testItem2), testCurrentGroup1.contents);
 		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootDeletion
+{
+	group1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testItem1 referringObjects]);
+
+		UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
+	}];
+}
+
+- (void)testSourcePersistentRootUndeletion
+{
+	group1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	group1.persistentRoot.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	{
+		UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testItem1 referringObjects]);
+		 
+		UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
 	}];
 }
 

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -175,7 +175,7 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(S(testItem2), testGroup1.contents);
@@ -195,9 +195,9 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem1 =
+		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
@@ -217,7 +217,7 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(S(testItem2), testGroup1.contents);
@@ -240,11 +240,11 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem1 =
+		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
 		UnorderedGroupNoOpposite *testOtherItem1 =
 			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKStringsEqual(@"other", testOtherItem1.label);
@@ -271,7 +271,7 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		 UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		 UnorderedGroupNoOpposite *testItem2 =
+		 OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 		 
 		 UKObjectsEqual(S(testItem2), testGroup1.contents);
@@ -294,11 +294,11 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		UnorderedGroupNoOpposite *testItem1 =
+		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
 		UnorderedGroupNoOpposite *testOtherItem1 =
 			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
-		UnorderedGroupNoOpposite *testItem2 =
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKStringsEqual(@"other", testOtherItem1.label);

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -331,8 +331,7 @@
 		OutlineItem *testCurrentOtherItem1 =
 			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
 
-		// FIXME: This test fails randomly every 5 run or so
-		//KObjectsEqual(S(testItem2), testCurrentGroup1.contents);
+		UKObjectsEqual(S(testItem2), testCurrentGroup1.contents);
 		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
@@ -353,6 +352,7 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
 		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
 		UnorderedGroupNoOpposite *testOtherItem1 =
@@ -366,14 +366,12 @@
 		UKObjectsNotEqual(S(testItem1, testItem2), testGroup1.contents);
 		// Check that the relationship cache knows the inverse relationship,
 		// even though it is not used in the metamodel (non-public API)
-		// FIXME: This test fails randomly every 5 run or so
-		//UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
 		
 		OutlineItem *testCurrentOtherItem1 =
-		[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
-		
-		// FIXME: This test fails randomly every 5 run or so
-		//UKObjectsEqual(S(testOtherItem1, testItem2), testCurrentGroup1.contents);
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+
+		UKObjectsEqual(S(testOtherItem1, testItem2), testCurrentGroup1.contents);
 		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -222,7 +222,14 @@
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
 		OutlineItem *testCurrentItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].currentBranch.rootObject;
-		
+
+		// Bidirectional cross persistent root relationships are limited to the
+		// tracking branch, this means item1 in the non-tracking current branch
+		// doesn't appear in testCurrentGroup1.contents and doesn't refer to it
+		// with an inverse relationship.
+		// Bidirectional cross persistent root relationships are supported
+		// accross current branches, but materialized accross tracking branches
+		// in memory (they are not visible accross the current branches in memory).
 		UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
 		UKTrue([testCurrentItem1 referringObjects].isEmpty);
 	}];

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -232,4 +232,58 @@
 	}];
 }
 
+/**
+ * The current branch cannot be deleted, so we cannot write a test method
+ * -testBranchDeletion analog to -testPersistentRootDeletion
+ */
+- (void)testBranchDeletionForReferenceToSpecificBranch
+{
+	group1.contents = S(otherItem1, item2);
+	[ctx commit];
+	
+	otherItem1.branch.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+											   inBlock:
+		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		 UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		 UnorderedGroupNoOpposite *testItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
+		 
+		 UKObjectsEqual(S(testItem2), testGroup1.contents);
+	}];
+}
+
+- (void)testBranchUndeletionForReferenceToSpecificBranch
+{
+	group1.contents = S(otherItem1, item2);
+	[ctx commit];
+	
+	otherItem1.branch.deleted = YES;
+	[ctx commit];
+
+	otherItem1.branch.deleted = NO;
+	[ctx commit];
+
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+											   inBlock:
+		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
+		UnorderedGroupNoOpposite *testOtherItem1 =
+			[testItem1.persistentRoot branchForUUID: otherItem1.branch.UUID].rootObject;
+		UnorderedGroupNoOpposite *testItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
+
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(S(testOtherItem1, testItem2), testGroup1.contents);
+		UKObjectsNotEqual(S(testItem1, testItem2), testGroup1.contents);
+	}];
+}
+
 @end

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -193,11 +193,13 @@
 
 - (void)testRelationships
 {
+	UnorderedGroupNoOpposite *currentGroup1 = group1.persistentRoot.currentBranch.rootObject;
+
 	UKObjectsEqual(S(item1, item2), group1.contents);
 	// Check that the relationship cache knows the inverse relationship,
 	// even though it is not used in the metamodel (non-public API)
-	UKObjectsEqual(S(group1, otherGroup1), [item1 referringObjects]);
-	UKObjectsEqual(S(group1, otherGroup1), [item2 referringObjects]);
+	UKObjectsEqual(S(group1, currentGroup1, otherGroup1), [item1 referringObjects]);
+	UKObjectsEqual(S(group1, currentGroup1, otherGroup1), [item2 referringObjects]);
 }
 
 - (void)testRelationshipsFromAndToCurrentBranches

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -175,10 +175,22 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OutlineItem *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
 		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(S(testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKTrue([testItem1 referringObjects].isEmpty);
+
+		UnorderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+
+		UKObjectsEqual(S(testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -195,12 +207,24 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
 		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
 		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testItem1 referringObjects]);
+
+		OutlineItem *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+		OutlineItem *testCurrentItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].currentBranch.rootObject;
+		
+		UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -217,10 +241,22 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OutlineItem *testItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
 		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
 		UKObjectsEqual(S(testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKTrue([testItem1 referringObjects].isEmpty);
+		
+		UnorderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testCurrentItem1 =
+			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].currentBranch.rootObject;
+		
+		UKObjectsEqual(S(testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -240,6 +276,7 @@
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
 		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
 		OutlineItem *testItem1 =
 			[testCtx persistentRootForUUID: item1.persistentRoot.UUID].rootObject;
 		UnorderedGroupNoOpposite *testOtherItem1 =
@@ -251,6 +288,15 @@
 		UKStringsEqual(@"current", testItem1.label);
 		UKObjectsEqual(S(testOtherItem1, testItem2), testGroup1.contents);
 		UKObjectsNotEqual(S(testItem1, testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
+		
+		OutlineItem *testCurrentOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+		
+		UKObjectsEqual(S(testOtherItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -270,11 +316,24 @@
 											   inBlock:
 		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
 	{
-		 UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
-		 OutlineItem *testItem2 =
+		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		OutlineItem *testOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].rootObject;
+		OutlineItem *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 		 
-		 UKObjectsEqual(S(testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		UKTrue([testOtherItem1 referringObjects].isEmpty);
+
+		UnorderedGroupNoOpposite *testCurrentGroup1 = testPersistentRoot.currentBranch.rootObject;
+		OutlineItem *testCurrentOtherItem1 =
+			[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+
+		// FIXME: This test fails randomly every 5 run or so
+		//KObjectsEqual(S(testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
 
@@ -305,6 +364,17 @@
 		UKStringsEqual(@"current", testItem1.label);
 		UKObjectsEqual(S(testOtherItem1, testItem2), testGroup1.contents);
 		UKObjectsNotEqual(S(testItem1, testItem2), testGroup1.contents);
+		// Check that the relationship cache knows the inverse relationship,
+		// even though it is not used in the metamodel (non-public API)
+		// FIXME: This test fails randomly every 5 run or so
+		//UKObjectsEqual(S(testGroup1, testCurrentGroup1), [testOtherItem1 referringObjects]);
+		
+		OutlineItem *testCurrentOtherItem1 =
+		[testCtx persistentRootForUUID: otherItem1.persistentRoot.UUID].currentBranch.rootObject;
+		
+		// FIXME: This test fails randomly every 5 run or so
+		//UKObjectsEqual(S(testOtherItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
 

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -411,4 +411,45 @@
 	}];
 }
 
+- (void)testSourceBranchDeletionForReferenceToSpecificBranch
+{
+	otherGroup1.contents = S(item1, item2);
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = YES;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	 {
+		 UKObjectsEqual(S(testItem1, testItem2), testOtherGroup1.contents);
+		 UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
+		 
+		 UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
+		 UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	 }];
+}
+
+- (void)testSourceBranchUndeletionForReferenceToSpecificBranch
+{
+	otherGroup1.contents = S(item1, item2);
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = YES;
+	[ctx commit];
+	
+	otherGroup1.branch.deleted = NO;
+	[ctx commit];
+	
+	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
+	 {
+		 UKStringsEqual(@"other", testOtherItem1.label);
+		 UKStringsEqual(@"current", testItem1.label);
+		 UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
+		 UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
+		 
+		 UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
+		 UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	 }];
+}
+
 @end

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -182,6 +182,26 @@
 	}];
 }
 
+- (void)testPersistentRootDeletionForReferenceToSpecificBranch
+{
+	group1.contents = S(otherItem1, item2);
+	[ctx commit];
+
+	item1.persistentRoot.deleted = YES;
+	[ctx commit];
+
+	[self checkPersistentRootWithExistingAndNewContext: group1.persistentRoot
+											   inBlock:
+		^(COEditingContext *testCtx, COPersistentRoot *testPersistentRoot, COBranch *testBranch, BOOL isNewContext)
+	{
+		UnorderedGroupNoOpposite *testGroup1 = testPersistentRoot.rootObject;
+		UnorderedGroupNoOpposite *testItem2 =
+			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
+
+		UKObjectsEqual(S(testItem2), testGroup1.contents);
+	}];
+}
+
 - (void)testPersistentRootUndeletionForReferenceToSpecificBranch
 {
 	group1.contents = S(otherItem1, item2);

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -118,7 +118,7 @@
 
 /**
  * For some general code comments that apply to all tests, see 
- * -testPersistentRootUndeletion.
+ * -testTargetPersistentRootUndeletion.
  */
 @interface TestCrossPersistentRootUnorderedRelationship : EditingContextTestCase <UKTest>
 {
@@ -197,7 +197,7 @@
 	UKTrue([currentItem2 referringObjects].isEmpty);
 }
 
-- (void)testPersistentRootDeletion
+- (void)testTargetPersistentRootDeletion
 {
 	item1.persistentRoot.deleted = YES;
 	[ctx commit];
@@ -212,7 +212,7 @@
 	}];
 }
 
-- (void)testPersistentRootUndeletion
+- (void)testTargetPersistentRootUndeletion
 {
 	item1.persistentRoot.deleted = YES;
 	[ctx commit];
@@ -239,7 +239,7 @@
 	}];
 }
 
-- (void)testPersistentRootDeletionForReferenceToSpecificBranch
+- (void)testTargetPersistentRootDeletionForReferenceToSpecificBranch
 {
 	group1.contents = S(otherItem1, item2);
 	[ctx commit];
@@ -257,7 +257,7 @@
 	}];
 }
 
-- (void)testPersistentRootUndeletionForReferenceToSpecificBranch
+- (void)testTargetPersistentRootUndeletionForReferenceToSpecificBranch
 {
 	group1.contents = S(otherItem1, item2);
 	[ctx commit];
@@ -283,9 +283,9 @@
 
 /**
  * The current branch cannot be deleted, so we cannot write a test method
- * -testBranchDeletion analog to -testPersistentRootDeletion
+ * -testTargetBranchDeletion analog to -testTargetPersistentRootDeletion
  */
-- (void)testBranchDeletionForReferenceToSpecificBranch
+- (void)testTargetBranchDeletionForReferenceToSpecificBranch
 {
 	group1.contents = S(otherItem1, item2);
 	[ctx commit];
@@ -303,7 +303,7 @@
 	}];
 }
 
-- (void)testBranchUndeletionForReferenceToSpecificBranch
+- (void)testTargetBranchUndeletionForReferenceToSpecificBranch
 {
 	group1.contents = S(otherItem1, item2);
 	[ctx commit];

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -118,8 +118,7 @@
 
 /**
  * For some general code comments that apply to all tests, see
- * -testTargetPersistentRootUndeletion, -testSourcePersistentRootUndeletion and
- * -testSourcePersistentRootUndeletionForReferenceToSpecificBranch.
+ * -testTargetPersistentRootUndeletion.
  *
  * For Relationship Source Deletion Tests, we test the referring objects that 
  * exist implicitly in the relationship cache, but are not exposed since the 

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -173,10 +173,7 @@
 		UnorderedGroupNoOpposite *testItem2 =
 			[testCtx persistentRootForUUID: item2.persistentRoot.UUID].rootObject;
 
-		// FIXME: The relationship cache needs some tweaking to keep track of
-		// dead relationships, since -referringObjects doesn't return testItem1
-		// in -[COObjectGraphContext replaceObject:withObject:].
-		//UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
 	}];
 }
 

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -117,8 +117,9 @@
 
 
 /**
- * For some general code comments that apply to all tests, see 
- * -testTargetPersistentRootUndeletion.
+ * For some general code comments that apply to all tests, see
+ * -testTargetPersistentRootUndeletion, -testSourcePersistentRootUndeletion and
+ * -testSourcePersistentRootUndeletionForReferenceToSpecificBranch.
  *
  * For Relationship Source Deletion Tests, we test the referring objects that 
  * exist implicitly in the relationship cache, but are not exposed since the 
@@ -428,13 +429,13 @@
 	[ctx commit];
 	
 	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
-	 {
+	{
 		 UKObjectsEqual(S(testItem1, testItem2), testOtherGroup1.contents);
 		 UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
 		 
 		 UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
 		 UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
-	 }];
+	}];
 }
 
 - (void)testSourceBranchUndeletionForReferenceToSpecificBranch
@@ -449,15 +450,15 @@
 	[ctx commit];
 	
 	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
-	 {
-		 UKStringsEqual(@"other", testOtherItem1.label);
-		 UKStringsEqual(@"current", testItem1.label);
-		 UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
-		 UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
-		 
-		 UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
-		 UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
-	 }];
+	{
+		UKStringsEqual(@"other", testOtherItem1.label);
+		UKStringsEqual(@"current", testItem1.label);
+		UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
+		UKObjectsEqual(S(testGroup1, testCurrentGroup1, testOtherGroup1, testCurrentOtherGroup1), [testItem1 referringObjects]);
+
+		UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);
+		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
+	}];
 }
 
 @end

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -119,6 +119,10 @@
 /**
  * For some general code comments that apply to all tests, see 
  * -testTargetPersistentRootUndeletion.
+ *
+ * For Relationship Source Deletion Tests, we test the referring objects that 
+ * exist implicitly in the relationship cache, but are not exposed since the 
+ * relationship is unidirectional.
  */
 @interface TestCrossPersistentRootUnorderedRelationship : EditingContextTestCase <UKTest>
 {
@@ -207,6 +211,8 @@
 	UKTrue([currentItem1 referringObjects].isEmpty);
 	UKTrue([currentItem2 referringObjects].isEmpty);
 }
+
+#pragma mark - Relationship Target Deletion Tests
 
 - (void)testTargetPersistentRootDeletion
 {
@@ -336,6 +342,8 @@
 		UKTrue([testCurrentOtherItem1 referringObjects].isEmpty);
 	}];
 }
+
+#pragma mark - Relationship Source Deletion Tests
 
 - (void)testSourcePersistentRootDeletion
 {

--- a/Tests/Relationship/TestUnorderedRelationshipWithOpposite.m
+++ b/Tests/Relationship/TestUnorderedRelationshipWithOpposite.m
@@ -316,7 +316,7 @@
 	[self checkPersistentRootsWithExistingAndNewContextInBlock: ^(CHECK_BLOCK_ARGS)
 	{
 		UKObjectsEqual(S(testItem1, testItem2), testGroup1.contents);
-		// testCurrentGroup1 present in -referrringObjects is hidden by -referringObjectsForPropertyInTarget:
+		// testCurrentGroup1 and testOtherGroup1 present in -referringObjects are hidden by -referringObjectsForPropertyInTarget:
 		UKObjectsEqual(S(testGroup1), testItem1.parentGroups);
 		 
 		UKObjectsEqual(S(testItem1, testItem2), testCurrentGroup1.contents);

--- a/Tests/TestCommon.h
+++ b/Tests/TestCommon.h
@@ -10,6 +10,7 @@
 #import <CoreObject/CoreObject.h>
 
 #import "COObjectGraphContext+GarbageCollection.h"
+#import "COPrimitiveCollection.h"
 #import "CODateSerialization.h"
 
 #import "COSynchronizerRevision.h"


### PR DESCRIPTION
Hey Eric,

Here are my latest changes to support both persistent root and branch deletion/undeletion with cross persistent root references.

--

The main changes are 

- updated COPrimitiveCollection concrete classes to track live vs dead references

- COCrossPersistentRootDeadRelationshipCache to track the relationships to be fixed when inner objects are undeleted (on the other side of the relationship)

- a new method -[COEditingContext updateCrossPersistentRootReferencesToPersistentRoot:Branch:isDeleted:] to call -[COObjectGraph replaceObject:withObject:] on explicit deletion/undeletion (e.g. -deletePersistentRoot:) and implicit deletion/undeletion coming through store change notifications (either for an undo track manipulation written directly to the store, or other external changes from another editing context)

- a rewritten -replaceReferencesToObjectIdenticalTo:withObject:

- COSerialization adjustments to return COPath markers for dead references, and serialize both live and dead references

- tests to cover the previous changes and few other issues

--

The current limitations are 

- -updateCrossPersistentRootReferencesToPersistentRoot:Branch:isDeleted: is currently unfaulting object graphs a bit aggressively, this can be improved later I think

- -[COMutableArray setArray:] should try to keep the dead references close to their initial position, based on some merge strategy, rather than putting them all at the end

- -[COObject replaceContentOfCollection: withCollection:propertyDescription:] is probably a useless change, I'd probably change it back to -mutableCollectionWithCollection:propertyDescription: and move the logic in -[COMutableArray setArray:] to a custom initializer (to prevent the user to accidentally inject dead references from one array into another one with the public API)

- cross persistent root keyed relationships are unfinished and untested (COMutableDictionary is ready but the rest isn't), it's not a high priority for me currently

- ivar-backed univalued relationships are unsupported currently, and more generally ivar-backed relationships are not covered by the tests ((I'll fix all that at some point) 


That's it :) Let me know if you have any questions.

Quentin.