### PR TITLE
Undo track store optional singleton

### DIFF
--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -178,8 +178,10 @@
  * To register types bound to classes manually, see
  * -[ETModelDescriptionRepository registerEntityDescriptionsForClasses:resolveNow:].
  *
- * For a nil model repository, or a repository that doesn't a COObject entity 
+ * For a nil model repository, or a repository that doesn't a COObject entity
  * description, raises a NSInvalidArgumentException.
+ *
+ * For a nil undo track store, raises a NSInvalidArgumentException.
  */
 - (instancetype)initWithStore: (COSQLiteStore *)store
    modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo

--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -10,7 +10,8 @@
 #import <CoreObject/COPersistentObjectContext.h>
 
 @class COSQLiteStore, COEditingContext, COPersistentRoot, COBranch, COObjectGraphContext, COObject;
-@class COUndoTrack, COCommandGroup, COCrossPersistentRootDeadRelationshipCache, CORevisionCache;
+@class COUndoTrackStore, COUndoTrack, COCommandGroup;
+@class COCrossPersistentRootDeadRelationshipCache, CORevisionCache;
 @class COError;
 
 /**
@@ -131,6 +132,7 @@
 	NSMutableSet *_persistentRootsPendingUndeletion;
 	COCrossPersistentRootDeadRelationshipCache *_deadRelationshipCache;
     /** Undo */
+	COUndoTrackStore *_undoTrackStore;
     BOOL _isRecordingUndo;
     COCommandGroup *_currentEditGroup;
 	CORevisionCache *_revisionCache;
@@ -153,15 +155,16 @@
 /**
  * Initializes a context which persists its content in the given store.
  *
- * The model repository is set to -[ETModelDescription mainRepository].
+ * The model repository is set to +[ETModelDescription mainRepository].
  *
  * See also -initWithStore:modelDescriptionRepository:.
  */
-- (id)initWithStore: (COSQLiteStore *)store;
+- (instancetype)initWithStore: (COSQLiteStore *)store;
 /**
  * <init />
- * Initializes a context which persists its content in the given store, and 
- * manages it using the metamodel provided by the model description repository.
+ * Initializes a context which persists its content in the given store,
+ * manages it using the metamodel provided by the model description repository, 
+ * and whose undo tracks are backed by the last store argument.
  *
  * When COObject entity description doesn't appear in the repository, this 
  * initializer invokes +newEntityDescription on COObject and its subclasses, 
@@ -178,15 +181,26 @@
  * For a nil model repository, or a repository that doesn't a COObject entity 
  * description, raises a NSInvalidArgumentException.
  */
-- (id)initWithStore: (COSQLiteStore *)store
-    modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo;
+- (instancetype)initWithStore: (COSQLiteStore *)store
+   modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+               undoTrackStore: (COUndoTrackStore *)aUndoTrackStore;
+/**
+ * Initializes a context which persists its content in the given store, and
+ * manages it using the metamodel provided by the model description repository.
+ *
+ * The undo track store is set to +[COUndoTrackStore defaultStore].
+ *
+ * See also -initWithStore:modelDescriptionRepository:undoTrackStore:.
+ */
+- (instancetype)initWithStore: (COSQLiteStore *)store
+   modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo;
 /**
  * Initializes the context with no store. 
  * As a result, the context content is not persisted.
  *
  * See also -initWithStore:.
  */
-- (id)init;
+- (instancetype)init;
 
 
 /** @taskunit Accessing All Persistent Roots */
@@ -217,6 +231,10 @@
  * describes all the persistent objects editable in the context.
  */
 @property (nonatomic, readonly, strong) ETModelDescriptionRepository *modelDescriptionRepository;
+/**
+ * Returns the store backing the undo tracks initialized with the receiver.
+ */
+@property (nonatomic, readonly, strong) COUndoTrackStore *undoTrackStore;
 
 
 /** @taskunit Managing Persistent Roots */

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -51,6 +51,7 @@
 {
 	NILARG_EXCEPTION_TEST(store);
 	NILARG_EXCEPTION_TEST(aRepo);
+	NILARG_EXCEPTION_TEST(anUndoTrackStore);
 	INVALIDARG_EXCEPTION_TEST(aRepo, [aRepo entityDescriptionForClass: [COObject class]] != nil);
 
 	SUPERINIT;

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -24,6 +24,7 @@
 #import "COCrossPersistentRootDeadRelationshipCache.h"
 #import "CORevisionCache.h"
 #import "COStoreTransaction.h"
+#import "COUndoTrackStore.h"
 #if TARGET_OS_IPHONE
 #import "NSDistributedNotificationCenter.h"
 #endif
@@ -34,7 +35,7 @@
 @synthesize persistentRootsPendingDeletion = _persistentRootsPendingDeletion;
 @synthesize persistentRootsPendingUndeletion = _persistentRootsPendingUndeletion;
 @synthesize deadRelationshipCache = _deadRelationshipCache;
-@synthesize isRecordingUndo = _isRecordingUndo;
+@synthesize undoTrackStore = _undoTrackStore, isRecordingUndo = _isRecordingUndo;
 
 #pragma mark Creating a New Context -
 
@@ -44,7 +45,9 @@
 	return [[self alloc] initWithStore: [[COSQLiteStore alloc] initWithURL: aURL]];
 }
 
-- (id)initWithStore: (COSQLiteStore *)store modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+- (instancetype)initWithStore: (COSQLiteStore *)store
+   modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+               undoTrackStore: (COUndoTrackStore *)anUndoTrackStore
 {
 	NILARG_EXCEPTION_TEST(store);
 	NILARG_EXCEPTION_TEST(aRepo);
@@ -58,6 +61,7 @@
 	_persistentRootsPendingDeletion = [NSMutableSet new];
     _persistentRootsPendingUndeletion = [NSMutableSet new];
 	_deadRelationshipCache = [COCrossPersistentRootDeadRelationshipCache new];
+	_undoTrackStore = anUndoTrackStore;
     _isRecordingUndo = YES;
 	_revisionCache = [[CORevisionCache alloc] initWithParentEditingContext: self];
 	_internalTransientObjectGraphContext = [[COObjectGraphContext alloc] initWithModelDescriptionRepository: aRepo];
@@ -82,13 +86,21 @@
 	return self;
 }
 
-- (id)initWithStore: (COSQLiteStore *)store
+- (instancetype)initWithStore: (COSQLiteStore *)store
+   modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+{
+	return [self initWithStore: store
+	modelDescriptionRepository: aRepo
+	            undoTrackStore: [COUndoTrackStore defaultStore]];
+}
+
+- (instancetype)initWithStore: (COSQLiteStore *)store
 {
 	return [self initWithStore: store
 	           modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]];
 }
 
-- (id)init
+- (instancetype)init
 {
 	return [self initWithStore: nil];
 }

--- a/CoreObject.xcodeproj/project.pbxproj
+++ b/CoreObject.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		608B3F4219FF045400304809 /* COMetamodel.m in Sources */ = {isa = PBXBuildFile; fileRef = 608B3F3E19FF045400304809 /* COMetamodel.m */; };
 		608D25F6192B475200BB7461 /* COObjectToArchivedData.h in Headers */ = {isa = PBXBuildFile; fileRef = 608D25F4192B475200BB7461 /* COObjectToArchivedData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		608D25F7192B475200BB7461 /* COObjectToArchivedData.m in Sources */ = {isa = PBXBuildFile; fileRef = 608D25F5192B475200BB7461 /* COObjectToArchivedData.m */; };
+		608F2C8F1B4D17F3007AED2E /* COUndoTrackStore+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 608F2C8E1B4D17F3007AED2E /* COUndoTrackStore+Private.h */; };
+		608F2C901B4D17F3007AED2E /* COUndoTrackStore+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 608F2C8E1B4D17F3007AED2E /* COUndoTrackStore+Private.h */; };
 		609C00651704C24C00D01AAB /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 609C00541704C24C00D01AAB /* main.m */; };
 		609C00801704C2BA00D01AAB /* CORevision.h in Headers */ = {isa = PBXBuildFile; fileRef = 609C00781704C2BA00D01AAB /* CORevision.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		609C00811704C2BA00D01AAB /* CORevision.m in Sources */ = {isa = PBXBuildFile; fileRef = 609C00791704C2BA00D01AAB /* CORevision.m */; };
@@ -1001,6 +1003,7 @@
 		608B3F3E19FF045400304809 /* COMetamodel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = COMetamodel.m; path = Core/COMetamodel.m; sourceTree = "<group>"; };
 		608D25F4192B475200BB7461 /* COObjectToArchivedData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = COObjectToArchivedData.h; sourceTree = "<group>"; };
 		608D25F5192B475200BB7461 /* COObjectToArchivedData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = COObjectToArchivedData.m; sourceTree = "<group>"; };
+		608F2C8E1B4D17F3007AED2E /* COUndoTrackStore+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "COUndoTrackStore+Private.h"; sourceTree = "<group>"; };
 		60951A2518884A3700687CF0 /* INSTALL.Cocoa.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = INSTALL.Cocoa.md; sourceTree = "<group>"; };
 		60951A2618884A3800687CF0 /* INSTALL.GNUstep.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = INSTALL.GNUstep.md; sourceTree = "<group>"; };
 		609C00541704C24C00D01AAB /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Tests/main.m; sourceTree = "<group>"; };
@@ -1758,6 +1761,7 @@
 				6646976D17CDB94900A1B767 /* Undo actions */,
 				66E62251185BEA51002A22C1 /* COTrack.h */,
 				663CE29317C07ED800E729F5 /* COUndoTrackStore.h */,
+				608F2C8E1B4D17F3007AED2E /* COUndoTrackStore+Private.h */,
 				663CE29417C07ED800E729F5 /* COUndoTrackStore.m */,
 				663CE2B417C0B05800E729F5 /* COEditingContext+Undo.h */,
 				663CE2B517C0B05800E729F5 /* COEditingContext+Undo.m */,
@@ -2488,6 +2492,7 @@
 				60E08D4619792FFA00D1B7AD /* COAttributedStringAttribute.h in Headers */,
 				60E08D5119792FFA00D1B7AD /* COStoreCreateBranch.h in Headers */,
 				60E08D4419792FFA00D1B7AD /* COAttributedStringChunk.h in Headers */,
+				608F2C901B4D17F3007AED2E /* COUndoTrackStore+Private.h in Headers */,
 				60E08D1319792FFA00D1B7AD /* COType.h in Headers */,
 				60E08D5B19792FFA00D1B7AD /* COStoreUndeletePersistentRoot.h in Headers */,
 				60E08D4B19792FFA00D1B7AD /* COStoreSetPersistentRootMetadata.h in Headers */,
@@ -2627,6 +2632,7 @@
 				66457FBF17E8BFE5003C51A8 /* COStoreSetCurrentBranch.h in Headers */,
 				66457FC117E8BFE5003C51A8 /* COStoreSetCurrentRevision.h in Headers */,
 				66457FC317E8BFE5003C51A8 /* COStoreTransaction.h in Headers */,
+				608F2C8F1B4D17F3007AED2E /* COUndoTrackStore+Private.h in Headers */,
 				608B3F3F19FF045400304809 /* COMetamodel.h in Headers */,
 				66457FC517E8BFE5003C51A8 /* COStoreUndeleteBranch.h in Headers */,
 				66457FC717E8BFE5003C51A8 /* COStoreUndeletePersistentRoot.h in Headers */,

--- a/Tests/Core/TestEditingContext.m
+++ b/Tests/Core/TestEditingContext.m
@@ -244,6 +244,7 @@
 
 - (void)testWithNoUndoTrackStore
 {
+	// Will retain the store as argument but not release it due to the exception
 	UKRaisesException([[COEditingContext alloc] initWithStore: store
 	                               modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]
 	                                           undoTrackStore: nil]);
@@ -304,14 +305,16 @@
 	__block BOOL receivedNotification = NO;
 	__block BOOL insideCommit = NO;
 	
-	[[NSNotificationCenter defaultCenter] addObserverForName: COEditingContextDidChangeNotification
-													  object: ctx
-													   queue: nil
-												  usingBlock: ^(NSNotification *notif) {
-													  receivedNotification = YES;
-													  UKTrue(insideCommit);
-													  UKRaisesException([ctx commit]);
-												  }];
+	id observer = [[NSNotificationCenter defaultCenter]
+		addObserverForName: COEditingContextDidChangeNotification
+		            object: ctx
+	                 queue: nil
+	            usingBlock: ^(NSNotification *notif)
+	{
+		receivedNotification = YES;
+		UKTrue(insideCommit);
+		UKRaisesException([ctx commit]);
+	}];
 		
 	COPersistentRoot *persistentRoot = [ctx insertNewPersistentRootWithEntityName: @"Anonymous.OutlineItem"];
 
@@ -320,6 +323,8 @@
 	insideCommit = NO;
 	
 	UKTrue(receivedNotification);
+	
+	[[NSNotificationCenter defaultCenter] removeObserver: observer];
 }
 
 @end

--- a/Tests/Core/TestEditingContext.m
+++ b/Tests/Core/TestEditingContext.m
@@ -234,8 +234,19 @@
 - (void) testWithNoStore
 {
 	UKRaisesException([[COEditingContext alloc] initWithStore: nil]);
-	UKRaisesException([[COEditingContext alloc] initWithStore: nil modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]]);
+	UKRaisesException([[COEditingContext alloc] initWithStore: nil
+	                               modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]]);
+	UKRaisesException([[COEditingContext alloc] initWithStore: nil
+	                               modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]
+	                                           undoTrackStore: [COUndoTrackStore defaultStore]]);
 	UKRaisesException([[COEditingContext alloc] init]);
+}
+
+- (void)testWithNoUndoTrackStore
+{
+	UKRaisesException([[COEditingContext alloc] initWithStore: store
+	                               modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]
+	                                           undoTrackStore: nil]);
 }
 
 - (void) testRevisionEqualityFromMultipleEditingContexts

--- a/Tests/SchemaMigration/TestSchemaMigration.m
+++ b/Tests/SchemaMigration/TestSchemaMigration.m
@@ -249,6 +249,8 @@
 	[self registerMigrationWithTestPackageVersion: 1 block: NULL];
 
 	[ctx commit];
+	// Will retain the current context store and never release it due to the exception
+	// (the store is retained when passed in argument to COEditingContext initializer)
 	UKRaisesException([self prepareNewMigrationContextForDestinationVersion: 1]);
 }
 

--- a/Tests/TestCommon.h
+++ b/Tests/TestCommon.h
@@ -73,6 +73,7 @@
 #import "COObjectGraphContext+Graphviz.h"
 #import "COEditingContext+Private.h"
 #import "COMetamodel.h"
+#import "COUndoTrackStore+Private.h"
 
 #import "diff.h"
 
@@ -133,7 +134,11 @@ doesNotPostNotification: (NSString *)notif;
  * This is a subdirectory of +temporaryDirectoryForTestStorage.
  */
 + (NSURL *)storeURL;
-
+/**
+ * Returns the URL used for the undo track store.
+ * This is a subdirectory of +temporaryDirectoryForTestStorage.
+ */
++ (NSURL *)undoTrackStoreURL;
 /**
  * Deletes all saved datas related to the store.
  *

--- a/Tests/TestCommon.h
+++ b/Tests/TestCommon.h
@@ -140,11 +140,12 @@ doesNotPostNotification: (NSString *)notif;
  */
 + (NSURL *)undoTrackStoreURL;
 /**
- * Deletes all saved datas related to the store.
+ * Deletes all saved datas related to the stores (this includes any undo track
+ * store created with +undoTrackStoreURL).
  *
  * Saved datas are usually .sqlitedb files.
  */
-+ (void)deleteStore;
++ (void)deleteStores;
 
 - (void) checkPersistentRoot: (ETUUID *)aPersistentRoot
 					 current: (ETUUID *)expectedCurrent

--- a/Tests/TestCommon.m
+++ b/Tests/TestCommon.m
@@ -240,12 +240,13 @@ doesNotPostNotification: (NSString *)notif
 	// Count up the number of open sqlite database connections at this
 	// point.
 	//
-	// As of 2014-01-24, there are 3 open connections:
+	// As of 2015-08-27, there are 3 open connections:
 	//
-	//  - In TestSynchronizer, -testBasicServerRevert and -testBasicClientRevert each leak a store.
-	//    (I don't understand why, but they're not so serious because
-	//     they only happen when throwing an exception in response to incorrect API usage.)
-	//
+	//  - In -[TestEditingContext testWithNoUndoTrackStore] and
+	//    -[TestSchemaMigration testExceptionOnMigrationReturningItemsWithIncorrectVersion]
+	//    the store is retained when passed as an argument, but never released
+	//    if an exception is thrown in the called method (this could be
+	//    considered a ARC bug or limitation).
 	//  - +[COUndoTrackStore defaultStore] intentionally opens and never closes a database connection
 	//    to the ~/Library/CoreObject/Undo/undo.sqlite database
 
@@ -253,7 +254,7 @@ doesNotPostNotification: (NSString *)notif
 	{
 		[FMDatabase logOpenDatabases];
 
-		const int expectedOpenDatabases = 4;
+		const int expectedOpenDatabases = 3;
 		if ([FMDatabase countOfOpenDatabases] > expectedOpenDatabases)
 		{
 			NSLog(@"ERROR: Expected only %d SQLite database connections to still be open.", expectedOpenDatabases);

--- a/Tests/TestCommon.m
+++ b/Tests/TestCommon.m
@@ -123,6 +123,11 @@ doesNotPostNotification: (NSString *)notif
 	return [[self temporaryURLForTestStorage] URLByAppendingPathComponent: @"TestStore.sqlite"];
 }
 
++ (NSURL *)undoTrackStoreURL
+{
+	return [[self temporaryURLForTestStorage] URLByAppendingPathComponent: @"TestUndoTrackStore.sqlite"];
+}
+
 - (void) checkPersistentRoot: (ETUUID *)aPersistentRoot
 					 current: (ETUUID *)expectedCurrent
 						head: (ETUUID *)expectedHead

--- a/Tests/Undo/TestUndo.m
+++ b/Tests/Undo/TestUndo.m
@@ -42,6 +42,12 @@
     return self;
 }
 
+- (COEditingContext *)newContext
+{
+	return [[COEditingContext alloc] initWithStore: [[COSQLiteStore alloc] initWithURL: ctx.store.URL]
+	                    modelDescriptionRepository: ctx.modelDescriptionRepository
+	                                undoTrackStore: ctx.undoTrackStore];
+}
 
 - (void)testUndoSetCurrentVersionForBranchBasic
 {
@@ -113,7 +119,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
 
 		COUndoTrack *rootEditTrack = [_rootEditTrack trackWithEditingContext: ctx2];
@@ -196,7 +202,7 @@
         
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
         COBranch *ctx2secondBranch = [ctx2persistentRoot branchForUUID: [secondBranch UUID]];
 
@@ -221,7 +227,7 @@
 	
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
         COBranch *ctx2secondBranch = [ctx2persistentRoot branchForUUID: [secondBranch UUID]];
 		
@@ -246,7 +252,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
         COBranch *ctx2secondBranch = [ctx2persistentRoot branchForUUID: [secondBranch UUID]];
 
@@ -274,7 +280,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
         COBranch *ctx2secondBranch = [ctx2persistentRoot branchForUUID: [secondBranch UUID]];
 
@@ -299,7 +305,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
 
 		COUndoTrack *testTrack = [_testTrack trackWithEditingContext: ctx2];
@@ -323,7 +329,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
 		
 		COUndoTrack *testTrack = [_testTrack trackWithEditingContext: ctx2];
@@ -352,7 +358,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
         COBranch *ctx2originalBranch = [ctx2persistentRoot branchForUUID: [originalBranch UUID]];
         COBranch *ctx2secondBranch = [ctx2persistentRoot branchForUUID: [secondBranch UUID]];
@@ -381,7 +387,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
 		
 		COUndoTrack *testTrack = [_testTrack trackWithEditingContext: ctx2];
@@ -402,7 +408,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
 		
 		COUndoTrack *testTrack = [_testTrack trackWithEditingContext: ctx2];
@@ -425,7 +431,7 @@
     
     // Load in another context
     {
-        COEditingContext *ctx2 = [COEditingContext contextWithURL: [store URL]];
+        COEditingContext *ctx2 = [self newContext];
         COPersistentRoot *ctx2persistentRoot = [ctx2 persistentRootForUUID: [persistentRoot UUID]];
 
 		COUndoTrack *testTrack = [_testTrack trackWithEditingContext: ctx2];

--- a/Tests/Undo/TestUndoTrackStore.m
+++ b/Tests/Undo/TestUndoTrackStore.m
@@ -21,7 +21,7 @@
 {
     SUPERINIT;
     
-    _store = [[COUndoTrackStore alloc] init];
+    _store = [[COUndoTrackStore alloc] initWithURL: [SQLiteStoreTestCase undoTrackStoreURL]];
 	[_store beginTransaction];
 	[_store removeTrackWithName: @"test1"];
 	[_store removeTrackWithName: @"test2"];

--- a/Undo/COCommandGroup.m
+++ b/Undo/COCommandGroup.m
@@ -13,6 +13,7 @@
 #import "CORevision.h"
 #import "CODateSerialization.h"
 #import "COUndoTrackStore.h"
+#import "COUndoTrackStore+Private.h"
 #import "COUndoTrack.h"
 #import "COEndOfUndoTrackPlaceholderNode.h"
 #import <EtoileFoundation/Macros.h>

--- a/Undo/COUndoTrack.h
+++ b/Undo/COUndoTrack.h
@@ -91,7 +91,6 @@ extern NSString * const kCOUndoTrackName;
 @interface COUndoTrack : NSObject <COTrack>
 {
 	@private
-    COUndoTrackStore *_store;
     NSString *_name;
 	NSMutableArray *_nodesOnCurrentUndoBranch;
 	NSMutableDictionary *_commandsByUUID;

--- a/Undo/COUndoTrack.m
+++ b/Undo/COUndoTrack.m
@@ -8,6 +8,7 @@
 #import <EtoileFoundation/EtoileFoundation.h>
 
 #import "COUndoTrackStore.h"
+#import "COUndoTrackStore+Private.h"
 #import "COUndoTrack.h"
 #import "COEditingContext+Undo.h"
 #import "COEditingContext+Private.h"
@@ -27,13 +28,12 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 
 
 @interface COUndoTrack ()
-@property (strong, readwrite, nonatomic) COUndoTrackStore *store;
 @property (strong, readwrite, nonatomic) NSString *name;
 @end
 
 @implementation COUndoTrack
 
-@synthesize name = _name, editingContext = _editingContext, store = _store;
+@synthesize name = _name, editingContext = _editingContext;
 @synthesize customRevisionMetadata;
 
 #pragma mark -
@@ -50,26 +50,21 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 + (COUndoTrack *)trackForName: (NSString *)aName
            withEditingContext: (COEditingContext *)aContext
 {
-	return [[self alloc] initWithStore: [COUndoTrackStore defaultStore]
-	                              name: aName
-	                    editingContext: aContext];
+	return [[self alloc] initWithName: aName editingContext: aContext];
 }
 
 + (COUndoTrack *)trackForPattern: (NSString *)aPattern
               withEditingContext: (COEditingContext *)aContext
 {
-	return [[COPatternUndoTrack alloc] initWithStore: [COUndoTrackStore defaultStore]
-	                                            name: aPattern
-	                                  editingContext: aContext];
+	return [[COPatternUndoTrack alloc] initWithName: aPattern
+	                                 editingContext: aContext];
 }
 
-- (id) initWithStore: (COUndoTrackStore *)aStore
-                name: (NSString *)aName
-	  editingContext: (COEditingContext *)aContext
+- (id) initWithName: (NSString *)aName
+     editingContext: (COEditingContext *)aContext
 {
     SUPERINIT;
     _name = aName;
-    _store = aStore;
 	_editingContext = aContext;
 	_trackStateForName = [NSMutableDictionary new];
 	_commandsByUUID = [NSMutableDictionary new];
@@ -77,7 +72,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	[[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(storeTrackDidChange:)
                                                  name: COUndoTrackStoreTrackDidChangeNotification
-                                               object: _store];
+                                               object: self.store];
 	
     return self;
 }
@@ -85,6 +80,11 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 - (void) dealloc
 {
 	[[NSNotificationCenter defaultCenter] removeObserver: self];
+}
+
+- (COUndoTrackStore *)store
+{
+	return _editingContext.undoTrackStore;
 }
 
 #pragma mark - Track Protocol - Convenience Methods
@@ -172,7 +172,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	if (targetIndex == currentIndex)
 		return YES;
 	
-	[_store beginTransaction];
+	[self.store beginTransaction];
 	
 	NSMutableArray *undo1 = [NSMutableArray new];
 	NSMutableArray *redo1 = [NSMutableArray new];
@@ -194,7 +194,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	
 	[self undo: undo1 redo: redo1 undo: @[] redo: @[]];
 	
-	BOOL ok = [_store commitTransaction];
+	BOOL ok = [self.store commitTransaction];
 	if (ok)
 	{
 		[self didUpdate];
@@ -233,7 +233,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	ETAssert(commonAncestorIndex != NSNotFound);
 	ETAssert(currentIndex != NSNotFound);
 
-	[_store beginTransaction];
+	[self.store beginTransaction];
 	
 	NSMutableArray *undo1 = [NSMutableArray new];
 	NSMutableArray *redo1 = [NSMutableArray new];
@@ -259,7 +259,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	
 	[self undo: undo1 redo: redo1 undo: @[] redo: redo2];
 	
-	BOOL ok = [_store commitTransaction];
+	BOOL ok = [self.store commitTransaction];
 	if (ok)
 	{
 		// FIXME: Not sure if we should need to call this explicitly, calling
@@ -331,12 +331,12 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	// Set ownership pointers (not parent UUID!)
 	[self setParentPointersForCommandGroup: aCommand];
 
-	[_store beginTransaction];
+	[self.store beginTransaction];
 	
 	[self loadIfNeeded];
 	
 	// Check our state
-	COUndoTrackState *storeState = [_store stateForTrackName: _name];
+	COUndoTrackState *storeState = [self.store stateForTrackName: _name];
 	if (!([state.headCommandUUID isEqual: storeState.headCommandUUID]
 		  && [state.currentCommandUUID isEqual: storeState.currentCommandUUID]))
 	{
@@ -376,7 +376,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	}
 	
 	COUndoTrackSerializedCommand *serialized = [aCommand serializedCommand];
-	[_store addCommand: serialized];
+	[self.store addCommand: serialized];
 	aCommand.sequenceNumber = serialized.sequenceNumber;
 	
 	// Write out the new store state
@@ -386,25 +386,25 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	newStoreState.currentCommandUUID = aCommand.UUID;
 	newStoreState.headCommandUUID = aCommand.UUID;
 	
-	[_store setTrackState: newStoreState];
+	[self.store setTrackState: newStoreState];
 	_trackStateForName[_name] = newStoreState;
 	
 	// Delete the obsolete last command created by coalescing
 	if (coalescedCommandUUIDToDelete != nil)
 	{
-		[_store removeCommandForUUID: coalescedCommandUUIDToDelete];
+		[self.store removeCommandForUUID: coalescedCommandUUIDToDelete];
 		[_commandsByUUID removeObjectForKey: coalescedCommandUUIDToDelete];
 	}
 
-	ETAssert([_store commitTransaction]);
+	ETAssert([self.store commitTransaction]);
 	[self reloadNodesOnCurrentBranch];
 }
 
 -(void)clear
 {
-	[_store beginTransaction];
-	[_store removeTrackWithName: _name];
-	ETAssert([_store commitTransaction]);
+	[self.store beginTransaction];
+	[self.store removeTrackWithName: _name];
+	ETAssert([self.store commitTransaction]);
 	
 	_nodesOnCurrentUndoBranch = nil;
 	[_commandsByUUID removeAllObjects];
@@ -573,7 +573,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	newStoreState.currentCommandUUID = newCurrentNodeUUID;
 	newStoreState.headCommandUUID = newHeadNodeUUID;
 	
-	[_store setTrackState: newStoreState];
+	[self.store setTrackState: newStoreState];
 	_trackStateForName[trackName] = newStoreState;
 }
 
@@ -647,7 +647,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 			}
 			
 			// Also make sure all commands have been loaded, including divergent ones
-			for (ETUUID *uuid in [_store allCommandUUIDsOnTrackWithName: _name])
+			for (ETUUID *uuid in [self.store allCommandUUIDsOnTrackWithName: _name])
 			{
 				[self commandForUUID: uuid];
 			}
@@ -677,10 +677,10 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	_nodesOnCurrentUndoBranch = [NSMutableArray new];
 	
 	// May be empty if we are uncommitted
-	NSArray *matchingNames = [_store trackNamesMatchingGlobPattern: _name];
+	NSArray *matchingNames = [self.store trackNamesMatchingGlobPattern: _name];
 	for (NSString *matchingName in matchingNames)
 	{
-		COUndoTrackState *trackState = [_store stateForTrackName: matchingName];
+		COUndoTrackState *trackState = [self.store stateForTrackName: matchingName];
 		_trackStateForName[matchingName] = trackState;
 	}
 	
@@ -707,7 +707,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	COCommandGroup *command = _commandsByUUID[aUUID];
 	if (command == nil)
 	{
-		COUndoTrackSerializedCommand *serializedCommand = [_store commandForUUID: aUUID];
+		COUndoTrackSerializedCommand *serializedCommand = [self.store commandForUUID: aUUID];
 		ETAssert([serializedCommand.UUID isEqual: aUUID]);
 		command = [self loadSerializedCommand: serializedCommand];
 		ETAssert([command.UUID isEqual: aUUID]);
@@ -773,7 +773,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 		notifState.currentCommandUUID = [ETUUID UUIDWithString: userInfo[COUndoTrackStoreTrackCurrentCommandUUID]];
 	}
 
-	if ([_store string: notifState.trackName matchesGlobPattern: _name])
+	if ([self.store string: notifState.trackName matchesGlobPattern: _name])
 	{
 		COUndoTrackState *inMemoryState = _trackStateForName[notifState.trackName];
 		if (![inMemoryState isEqual: notifState])

--- a/Undo/COUndoTrackStore+Private.h
+++ b/Undo/COUndoTrackStore+Private.h
@@ -1,0 +1,64 @@
+/**
+	Copyright (C) 2013 Eric Wasylishen
+
+	Date:  August 2013
+	License:  MIT  (see COPYING)
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FMDatabase;
+@class ETUUID;
+
+NSString * const COUndoTrackStoreTrackDidChangeNotification;
+
+// User info keys for COUndoTrackStoreTrackDidChangeNotification
+NSString * const COUndoTrackStoreTrackName;
+/**
+ * UUID string
+ */
+NSString * const COUndoTrackStoreTrackHeadCommandUUID;
+/**
+ * NSNull or UUID string
+ */
+NSString * const COUndoTrackStoreTrackCurrentCommandUUID;
+
+@interface COUndoTrackSerializedCommand : NSObject
+@property (nonatomic, readwrite, strong) id JSONData;
+@property (nonatomic, readwrite, strong) NSDictionary *metadata;
+@property (nonatomic, readwrite, copy) ETUUID *UUID;
+@property (nonatomic, readwrite, copy) ETUUID *parentUUID;
+@property (nonatomic, readwrite, copy) NSString *trackName;
+@property (nonatomic, readwrite, copy) NSDate *timestamp;
+@property (nonatomic, readwrite, assign) int64_t sequenceNumber;
+@end
+
+@interface COUndoTrackState : NSObject <NSCopying>
+@property (nonatomic, readwrite, copy) NSString *trackName;
+@property (nonatomic, readwrite, copy) ETUUID *headCommandUUID;
+@property (nonatomic, readwrite, copy) ETUUID *currentCommandUUID;
+@end
+
+
+@interface COUndoTrackStore ()
+
+- (BOOL) beginTransaction;
+- (BOOL) commitTransaction;
+
+- (NSArray *) trackNames;
+- (NSArray *) trackNamesMatchingGlobPattern: (NSString *)aPattern;
+- (COUndoTrackState *) stateForTrackName: (NSString*)aName;
+- (void) setTrackState: (COUndoTrackState *)aState;
+- (void) removeTrackWithName: (NSString*)aName;
+- (NSArray *) allCommandUUIDsOnTrackWithName: (NSString*)aName;
+
+/**
+ * sequenceNumber is set in the provided command object
+ */
+- (void) addCommand: (COUndoTrackSerializedCommand *)aCommand;
+- (COUndoTrackSerializedCommand *) commandForUUID: (ETUUID *)aUUID;
+- (void) removeCommandForUUID: (ETUUID *)aUUID;
+
+- (BOOL) string: (NSString *)aString matchesGlobPattern: (NSString *)aPattern;
+
+@end

--- a/Undo/COUndoTrackStore.h
+++ b/Undo/COUndoTrackStore.h
@@ -11,62 +11,72 @@
 @class FMDatabase;
 @class ETUUID;
 
-NSString * const COUndoTrackStoreTrackDidChangeNotification;
-
-// User info keys for COUndoTrackStoreTrackDidChangeNotification
-NSString * const COUndoTrackStoreTrackName;
 /**
- * UUID string
+ * @group Undo
+ * @abstract A specialized store to persist undo tracks.
+ *
+ * @section Conceptual Model
+ *
+ * If you intend to share a CoreObject store with multiple applications, the 
+ * default undo track store should be used, otherwise it's usually better to
+ * use an undo track store that remains private to your application.
+ *
+ * With a private undo track store, the history can be backed up and compacted 
+ * without worrying about other applications.
+ *
+ * With the default undo track store, you cannot replace the database on disk 
+ * at run-time and reload the instance returned by +[COUndoTrackStore defaultStore], 
+ * since other applications can be using it.
+ *
+ * @section Current Limitations
+ *
+ * For now, COUndoTrackStore doesn't post distributed notifications, so undo 
+ * tracks have no way to observe multiple instances of the same store 
+ * (COUndoTrackStore objects initialized with the same URL). This means 
+ * COUndoTrack will only track changes posted by the undo track store instance
+ * of their editing context.
+ *
+ * For the default undo track store, all CoreObject applications must link
+ * CoreObject versions whose COUndoTrackStore schema versions are identical.
  */
-NSString * const COUndoTrackStoreTrackHeadCommandUUID;
-/**
- * NSNull or UUID string
- */
-NSString * const COUndoTrackStoreTrackCurrentCommandUUID;
-
-@interface COUndoTrackSerializedCommand : NSObject
-@property (nonatomic, readwrite, strong) id JSONData;
-@property (nonatomic, readwrite, strong) NSDictionary *metadata;
-@property (nonatomic, readwrite, copy) ETUUID *UUID;
-@property (nonatomic, readwrite, copy) ETUUID *parentUUID;
-@property (nonatomic, readwrite, copy) NSString *trackName;
-@property (nonatomic, readwrite, copy) NSDate *timestamp;
-@property (nonatomic, readwrite, assign) int64_t sequenceNumber;
-@end
-
-@interface COUndoTrackState : NSObject <NSCopying>
-@property (nonatomic, readwrite, copy) NSString *trackName;
-@property (nonatomic, readwrite, copy) ETUUID *headCommandUUID;
-@property (nonatomic, readwrite, copy) ETUUID *currentCommandUUID;
-@end
-
 @interface COUndoTrackStore : NSObject
 {
+	@private
+	NSURL *_URL;
     FMDatabase *_db;
 	NSMutableDictionary *_modifiedTrackStateForTrackName;
 }
 
-+ (COUndoTrackStore *) defaultStore;
 
-/** @taskunit Framework Private */
-
-- (BOOL) beginTransaction;
-- (BOOL) commitTransaction;
-
-- (NSArray *) trackNames;
-- (NSArray *) trackNamesMatchingGlobPattern: (NSString *)aPattern;
-- (COUndoTrackState *) stateForTrackName: (NSString*)aName;
-- (void) setTrackState: (COUndoTrackState *)aState;
-- (void) removeTrackWithName: (NSString*)aName;
-- (NSArray *) allCommandUUIDsOnTrackWithName: (NSString*)aName;
+/** @taskunit Initialization */
 
 /**
- * sequenceNumber is set in the provided command object
+ * Returns the default store that can shared by CoreObject applications.
+ *
+ * This store is backed by a single database on disk per user account.
  */
-- (void) addCommand: (COUndoTrackSerializedCommand *)aCommand;
-- (COUndoTrackSerializedCommand *) commandForUUID: (ETUUID *)aUUID;
-- (void) removeCommandForUUID: (ETUUID *)aUUID;
++ (instancetype)defaultStore;
+/**
+ * <init />
+ * Returns a new store backed by the database located at the given URL.
+ *
+ * If there is no database at the given URL, a new one is created, otherwise 
+ * the existing one is reused.
+ *
+ * For a nil argument or a URL which doesn't referenced the local filesystem,
+ * raises a NSInvalidArgumentException.
+ */
+- (instancetype)initWithURL: (NSURL *)aURL;
 
-- (BOOL) string: (NSString *)aString matchesGlobPattern: (NSString *)aPattern;
+
+/** @taskunit Basic Properties */
+
+
+/**
+ * The database URL.
+ *
+ * See also -initWithURL:.
+ */
+@property (nonatomic, readonly) NSURL *URL;
 
 @end

--- a/Undo/COUndoTrackStore.m
+++ b/Undo/COUndoTrackStore.m
@@ -6,6 +6,7 @@
  */
 
 #import "COUndoTrackStore.h"
+#import "COUndoTrackStore+Private.h"
 #import "COUndoTrack.h"
 #import <EtoileFoundation/EtoileFoundation.h>
 #import "FMDatabase.h"
@@ -100,35 +101,55 @@ NSString * const COUndoTrackStoreTrackCurrentCommandUUID = @"COUndoTrackStoreTra
 
 @implementation COUndoTrackStore
 
-+ (COUndoTrackStore *) defaultStore
+@synthesize URL = _URL;
+
++ (NSURL *)defaultStoreURL
+{
+    NSArray *libraryDirs = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+
+    return [NSURL fileURLWithPath: [[libraryDirs[0] stringByAppendingPathComponent: @"CoreObject"]
+		stringByAppendingPathComponent: @"Undo"]];
+}
+
++ (instancetype)defaultStore
 {
     static COUndoTrackStore *store;
     if (store == nil)
     {
-        store = [[COUndoTrackStore alloc] init];
+        store = [[COUndoTrackStore alloc] initWithURL: [self defaultStoreURL]];
     }
     return store;
 }
 
-- (id) init
+- (instancetype)initWithURL: (NSURL *)aURL
 {
+	NILARG_EXCEPTION_TEST(aURL);
+	INVALIDARG_EXCEPTION_TEST(aURL, aURL.isFileURL);
     SUPERINIT;
-    
+	
+	BOOL isDir = NO;
+
+	if (![[NSFileManager defaultManager] fileExistsAtPath: aURL.path
+	                                          isDirectory: &isDir])
+	{
+		NSError *error = nil;
+
+		[[NSFileManager defaultManager] createDirectoryAtURL: aURL
+    	                         withIntermediateDirectories: YES
+    	                                          attributes: nil
+		                                               error: &error];
+		ETAssert(error == nil);
+	}
+	else
+	{
+		ETAssert(isDir);
+	}
+
+	_URL = aURL;
 	_modifiedTrackStateForTrackName = [NSMutableDictionary new];
 	
-    NSArray *libraryDirs = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
-
-    NSString *dir = [[[libraryDirs objectAtIndex: 0]
-                      stringByAppendingPathComponent: @"CoreObject"]
-                        stringByAppendingPathComponent: @"Undo"];
-
-    [[NSFileManager defaultManager] createDirectoryAtPath: dir
-                              withIntermediateDirectories: YES
-                                               attributes: nil
-                                                    error: NULL];
-	
     @autoreleasepool {
-		_db = [[FMDatabase alloc] initWithPath: [dir stringByAppendingPathComponent: @"undo.sqlite"]];
+		_db = [[FMDatabase alloc] initWithPath: [aURL.path stringByAppendingPathComponent: @"undo.sqlite"]];
 		[_db setShouldCacheStatements: YES];
 		[_db setLogsErrors: YES];
 		assert([_db open]);
@@ -159,6 +180,11 @@ NSString * const COUndoTrackStoreTrackCurrentCommandUUID = @"COUndoTrackStoreTra
 							 "FOREIGN KEY(currentid) REFERENCES commands(id))"];
 	}
     return self;
+}
+
+- (instancetype)init
+{
+	return [self initWithURL: nil];
 }
 
 - (void) dealloc


### PR DESCRIPTION
For the issue #21, I gave some more thoughts to the problem. I also hit some other related issues while working on the history compaction, which motivated me to work out a cleaner approach.

The core problem is that the undo track store is a singleton. This works nicely when applications (using the same CoreObject version) want to use a common CoreObject store and share their histories, but in other more sandboxed situations, it can be troublesome. 

So I made some changes to make the singleton optional, the framework user can now provide a custom undo track store to the editing context. The undo tracks now request this store to their editing context. When using a custom undo track store, releasing editing contexts and their undo tracks will now release all CoreObject state in the current process. 

The main use cases are:

- applications that don't want to mix their history with other applications
- swapping stores at run-time (for backup support)
- using incompatible CoreObject versions on the same system
- testing undo tracks with a pristine state
- avoiding mixing test histories with real application histories

The last two points are problems I encoundered while working on history compaction.
The second point is related to issue #21.

The conceptual model and current limitations are documented in COUndoTrackStore class description.

btw, I think I figured out the issues about opened vs closed connections we had. Basically when an exception is raised, between the frame where where an exception is thrown and the one where it's caught, all arguments that got retained by ARC won't get released.