### PR TITLE
COObject multivalue optimizations

### DIFF
--- a/Benchmark/TestObjectPerformance.m
+++ b/Benchmark/TestObjectPerformance.m
@@ -289,19 +289,27 @@ static const int LARGE_RELATIONSHIP_SIZE = 1000;
 - (void) testCreateLargeOrderedRelationsip
 {
 	// compare speed of COObject's -addObject: with NSMutableArray's
+	NSMutableArray *items = [NSMutableArray new];
 	__block int i = 0;
 	[self timeBlock: ^(void) {
 		OutlineItem *child = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
 		child.label = [NSString stringWithFormat: @"%d", i++];
+		[items addObject: child];
+	} iterations: LARGE_RELATIONSHIP_SIZE message: @"Create OutlineItem and add to an NSMutableArray with -addObject:"];
+	
+	// compare speed of COObject's -addObject: with NSMutableArray's
+	i = 0;
+	[self timeBlock: ^(void) {
+		OutlineItem *child = items[i++];
 		[coreobjectParent addObject: child];
-	} iterations: LARGE_RELATIONSHIP_SIZE message: @"Create OutlineItem and add to an OutlineItem with -addObject:"];
+	} iterations: LARGE_RELATIONSHIP_SIZE message: @"Add OutlineItem to an OutlineItem with -addObject:"];
 
 	NSMutableArray *nsmutablearray = [NSMutableArray new];
+	i = 0;
 	[self timeBlock: ^(void) {
-		OutlineItem *child = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
-		child.label = [NSString stringWithFormat: @"%d", i++];
+		OutlineItem *child = items[i++];
 		[nsmutablearray addObject: child];
-	} iterations: LARGE_RELATIONSHIP_SIZE message: @"Create OutlineItem and add to an NSMutableArray with -addObject:"];
+	} iterations: LARGE_RELATIONSHIP_SIZE message: @"Add OutlineItem to an NSMutableArray with -addObject:"];
 	
 	// test -count
 	
@@ -321,14 +329,14 @@ static const int LARGE_RELATIONSHIP_SIZE = 1000;
 	[self timeBlock: ^(void) {
 		for (OutlineItem *child in parentContentsArray)
 		{
-			count += [child.label intValue];
+			count += (intptr_t)(child);
 		}
 	} message: [NSString stringWithFormat: @"for/in loop on CoreObject array with %d elements", LARGE_RELATIONSHIP_SIZE]];
 	
 	[self timeBlock: ^(void) {
 		for (OutlineItem *child in parentContentsArrayCopy)
 		{
-			count += [child.label intValue];
+			count += (intptr_t)(child);
 		}
 	} message: [NSString stringWithFormat: @"for/in loop on NSArray with %d elements", LARGE_RELATIONSHIP_SIZE]];
 }

--- a/Benchmark/TestObjectPerformance.m
+++ b/Benchmark/TestObjectPerformance.m
@@ -217,3 +217,121 @@ TIME_METHOD(timeToModifyCoreObjectOrderedRelationship, MODIFICATION_ITERATIONS, 
 }
 
 @end
+
+@implementation TestCase (Timing)
+
+#pragma mark - Timing Methods
+
+// TODO: Timing infrastructure earlier in the file, using macros, looks awful.
+// Convert to use this.
+- (NSTimeInterval) timeBlock: (void (^)())aBlock iterations: (NSUInteger)iterations
+{
+	NSDate *start = [NSDate date];
+	for (NSUInteger i=0; i<iterations; i++)
+	{
+		aBlock();
+	}
+	NSTimeInterval time = [[NSDate date] timeIntervalSinceDate: start] / iterations;
+	return time;
+}
+
+static const int DEFAULT_ITERATIONS = 1000;
+
+static NSString *FormatTimeInterval(NSTimeInterval s)
+{
+	double us = s * US_PER_SECOND;
+	double ms = s * 1000.0;
+	if (ms > 1000)
+		return [NSString stringWithFormat: @"%f s", s];
+	else if (us > 1000)
+		return [NSString stringWithFormat: @"%f ms", ms];
+	else
+		return [NSString stringWithFormat: @"%f us", us];
+}
+
+- (void) timeBlock: (void (^)())aBlock iterations: (NSUInteger)iterations message: (NSString *)message
+{
+	NSTimeInterval time = [self timeBlock: aBlock iterations: iterations];
+	NSLog(@"%@ per iteration for '%@'", FormatTimeInterval(time), message);
+}
+
+
+- (void) timeBlock: (void (^)())aBlock message: (NSString *)message
+{
+	[self timeBlock: aBlock iterations:DEFAULT_ITERATIONS message: message];
+}
+
+@end
+
+#pragma mark - Test large relationships
+
+@interface TestLargeOrderedRelationsip : TestCase <UKTest>
+{
+	COObjectGraphContext *objectGraphContext;
+	OutlineItem *coreobjectParent;
+}
+@end
+
+@implementation TestLargeOrderedRelationsip
+
+- (id)init
+{
+	SUPERINIT;
+	objectGraphContext = [COObjectGraphContext new];
+	coreobjectParent = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
+	return self;
+}
+
+static const int LARGE_RELATIONSHIP_SIZE = 1000;
+
+// 2015-09-04: Typewriter performance is getting unusably slow on small documents
+
+- (void) testCreateLargeOrderedRelationsip
+{
+	// compare speed of COObject's -addObject: with NSMutableArray's
+	__block int i = 0;
+	[self timeBlock: ^(void) {
+		OutlineItem *child = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
+		child.label = [NSString stringWithFormat: @"%d", i++];
+		[coreobjectParent addObject: child];
+	} iterations: LARGE_RELATIONSHIP_SIZE message: @"Create OutlineItem and add to an OutlineItem with -addObject:"];
+
+	NSMutableArray *nsmutablearray = [NSMutableArray new];
+	[self timeBlock: ^(void) {
+		OutlineItem *child = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
+		child.label = [NSString stringWithFormat: @"%d", i++];
+		[nsmutablearray addObject: child];
+	} iterations: LARGE_RELATIONSHIP_SIZE message: @"Create OutlineItem and add to an NSMutableArray with -addObject:"];
+	
+	// test -count
+	
+	NSArray *parentContentsArray = coreobjectParent.contents;
+	__block NSUInteger count = 0;
+	[self timeBlock: ^(void) {
+		count += [parentContentsArray count];
+	} message: [NSString stringWithFormat: @"-count on CoreObject array with %d elements", LARGE_RELATIONSHIP_SIZE]];
+	
+	NSArray *parentContentsArrayCopy = [NSArray arrayWithArray: coreobjectParent.contents];
+	[self timeBlock: ^(void) {
+		count += [parentContentsArrayCopy count];
+	} message: [NSString stringWithFormat: @"-count on NSArray with %d elements", LARGE_RELATIONSHIP_SIZE]];
+	
+	// test for/in loop
+	
+	[self timeBlock: ^(void) {
+		for (OutlineItem *child in parentContentsArray)
+		{
+			count += [child.label intValue];
+		}
+	} message: [NSString stringWithFormat: @"for/in loop on CoreObject array with %d elements", LARGE_RELATIONSHIP_SIZE]];
+	
+	[self timeBlock: ^(void) {
+		for (OutlineItem *child in parentContentsArrayCopy)
+		{
+			count += [child.label intValue];
+		}
+	} message: [NSString stringWithFormat: @"for/in loop on NSArray with %d elements", LARGE_RELATIONSHIP_SIZE]];
+}
+
+
+@end

--- a/Core/COObject+RelationshipCache.h
+++ b/Core/COObject+RelationshipCache.h
@@ -21,4 +21,10 @@
 - (void) addCachedOutgoingRelationshipsForCollectionValue: (id)obj
 								ofPropertyWithDescription: (ETPropertyDescription *)aProperty;
 
+- (void) removeCachedOutgoingRelationshipsForValue: (id)aValue
+						 ofPropertyWithDescription: (ETPropertyDescription *)aProperty;
+
+- (void) addCachedOutgoingRelationshipsForValue: (id)aValue
+					  ofPropertyWithDescription: (ETPropertyDescription *)aProperty;
+
 @end

--- a/Core/COObject+RelationshipCache.h
+++ b/Core/COObject+RelationshipCache.h
@@ -15,4 +15,10 @@
                             ofPropertyWithDescription: (ETPropertyDescription *)aProperty;
 - (void) removeCachedOutgoingRelationships;
 
+- (void) removeCachedOutgoingRelationshipsForCollectionValue: (id)obj
+								   ofPropertyWithDescription: (ETPropertyDescription *)aProperty;
+
+- (void) addCachedOutgoingRelationshipsForCollectionValue: (id)obj
+								ofPropertyWithDescription: (ETPropertyDescription *)aProperty;
+
 @end

--- a/Core/COObject.h
+++ b/Core/COObject.h
@@ -412,10 +412,10 @@
 	 */
     CORelationshipCache *_incomingRelationshipCache;
 	/**
-	 * Stack of old collection values during nested change notifications i.e. 
+	 * Stack of nested property names for change notifications i.e.
 	 * -willChangeValueForProperty: is called multiple times for the same object.
 	 */
-	NSMutableArray *_oldValues;
+	NSMutableArray *_propertyChangeStack;
 	/**
 	 * Dictionary UUIDs by property names. Used by 
 	 * -[COObject storeItemFromDictionaryForPropertyDescription:] to recreate 

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1312,12 +1312,16 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 	{
 		[(id <COPrimitiveCollection>)newValue setMutable: NO];
 	}
-	if ([self removeDuplicatesInValue: newValue propertyDescription: propertyDesc])
+	else
 	{
-		// the -removeDuplicatesInValue:propertyDescription: method removed some
-		// duplicates and saved the resulting de-duplicated collection in the storage
-		// again. Reload the new value.
-		newValue = [self valueForStorageKey: key];
+		// COPrimitiveCollection handles duplicate removal itself
+		if ([self removeDuplicatesInValue: newValue propertyDescription: propertyDesc])
+		{
+			// the -removeDuplicatesInValue:propertyDescription: method removed some
+			// duplicates and saved the resulting de-duplicated collection in the storage
+			// again. Reload the new value.
+			newValue = [self valueForStorageKey: key];
+		}
 	}
 	
 	[self validateNewValue: newValue propertyDescription: propertyDesc];

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1500,7 +1500,10 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 		}
 		replacedOrRemoved = objs;
 	}
-	else ETAssert(NO);
+	else
+	{
+		ETAssert(NO);
+	}
 
 	// Do the various validations / updates for the removed and added objects.
 	

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -58,7 +58,6 @@
 
 @property (nonatomic, readonly) NSPointerArray *backing;
 
-- (NSUInteger)referencesCount;
 - (id)referenceAtIndex: (NSUInteger)index;
 - (void)addReference: (id)aReference;
 - (void)replaceReferenceAtIndex: (NSUInteger)index withReference: (id)aReference;

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -38,16 +38,27 @@
 - (BOOL)containsReference: (id)aReference;
 @end
 
+/**
+ * References are either COPath or any other object.
+ *
+ * COPath are treated as "tombstones" and hidden from the NSArray
+ * access methods (-count, -objectAtIndex:, etc.)
+ */
 @interface COMutableArray : NSMutableArray <COPrimitiveCollection>
 {
 @public
 	BOOL _mutable;
 	NSPointerArray *_backing;
-	NSMutableIndexSet *_deadIndexes;
+	/**
+	 * Array of integers, the ith entry gives the backing index for
+	 * "external" index i.
+	 */
+	NSPointerArray *_externalIndexToBackingIndex;
 }
 
 @property (nonatomic, readonly) NSPointerArray *backing;
 
+- (NSUInteger)referencesCount;
 - (id)referenceAtIndex: (NSUInteger)index;
 - (void)addReference: (id)aReference;
 - (void)replaceReferenceAtIndex: (NSUInteger)index withReference: (id)aReference;

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -61,6 +61,7 @@
 	// TODO: Replace with custom acquire/relinquish functions to retain/release
 	// COPath references as necessary
 	NSMutableSet *_deadReferences;
+	NSHashTable *_backingHashTable;
 }
 @end
 

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -145,10 +145,10 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	const NSUInteger externalCount = [_externalIndexToBackingIndex count];
 	for (NSUInteger i = 0; i < externalCount; i++)
 	{
-		const NSInteger backingI  = (NSInteger)[_externalIndexToBackingIndex pointerAtIndex: i];
+		const NSUInteger backingI  = (NSUInteger)[_externalIndexToBackingIndex pointerAtIndex: i];
 		if (backingI >= index)
 		{
-			const NSInteger shifted = backingI + delta;
+			const NSUInteger shifted = backingI + delta;
 			[_externalIndexToBackingIndex replacePointerAtIndex: i
 													withPointer: (void *)shifted];
 		}

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -376,7 +376,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	}
 
 	// remove old value from hash table
-	[_backingHashTable removeObject: [_backing pointerAtIndex: index]];
+	id oldValue = [_backing pointerAtIndex: index];
+	[_backingHashTable removeObject: oldValue];
+	if ([oldValue isKindOfClass: [COPath class]])
+	{
+		[_deadReferences removeObject: oldValue];
+	}
 
 	[super replaceReferenceAtIndex: index withReference: aReference];
 	if ([aReference isKindOfClass: [COPath class]])
@@ -497,21 +502,21 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 - (void)addReference: (id)aReference
 {
 	COThrowExceptionIfNotMutable(_mutable);
+	[_backing addObject: aReference];
 	if ([aReference isKindOfClass: [COPath class]])
 	{
 		[_deadReferences addObject: aReference];
 	}
-	[_backing addObject: aReference];
 }
 
 - (void)removeReference: (id)aReference
 {
 	COThrowExceptionIfNotMutable(_mutable);
+	[_backing removeObject: aReference];
 	if ([aReference isKindOfClass: [COPath class]])
 	{
 		[_deadReferences removeObject: aReference];
 	}
-	[_backing removeObject: aReference];
 }
 
 - (BOOL)containsReference: (id)aReference
@@ -552,12 +557,16 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 - (void)addObject: (id)anObject
 {
 	COThrowExceptionIfNotMutable(_mutable);
+	ETAssert(![anObject isKindOfClass: [COPath class]]);
+		
 	[_backing addObject: anObject];
 }
 
 - (void)removeObject: (id)anObject
 {
 	COThrowExceptionIfNotMutable(_mutable);
+	ETAssert(![anObject isKindOfClass: [COPath class]]);
+	
 	[_backing removeObject: anObject];
 }
 

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -275,7 +275,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 {
 	COThrowExceptionIfNotMutable(_mutable);
 
-	NSArray *deadReferences = [_backing.allObjects filteredCollectionWithBlock: ^(id obj){
+	NSArray *deadReferences = [_backing.allObjects filteredCollectionWithBlock: ^(id obj) {
 		return [obj isKindOfClass: [COPath class]];
 	}];
 							   

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -106,11 +106,6 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	return _backing;
 }
 
-- (NSUInteger)referencesCount
-{
-	return _backing.count;
-}
-
 - (id)referenceAtIndex: (NSUInteger)index
 {
 	return [_backing pointerAtIndex: index];

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -108,7 +108,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (NSUInteger)referencesCount
 {
-	return [_backing count];
+	return _backing.count;
 }
 
 - (id)referenceAtIndex: (NSUInteger)index
@@ -121,14 +121,14 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	COThrowExceptionIfNotMutable(_mutable);
 	if (![aReference isKindOfClass: [COPath class]])
 	{
-		[_externalIndexToBackingIndex addPointer: (void *)[_backing count]];
+		[_externalIndexToBackingIndex addPointer: (void *)_backing.count];
 	}
 	[_backing addPointer: (__bridge void *)aReference];
 }
 
 - (NSUInteger)firstExternalIndexGreaterThanOrEqualToBackingIndex: (NSUInteger)index
 {
-	const NSUInteger externalCount = [_externalIndexToBackingIndex count];
+	const NSUInteger externalCount = _externalIndexToBackingIndex.count;
 	for (NSUInteger externalI = 0; externalI < externalCount; externalI++)
 	{
 		const NSUInteger backingI  = (NSUInteger)[_externalIndexToBackingIndex pointerAtIndex: externalI];
@@ -142,7 +142,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)shiftBackingIndicesGreaterThanOrEqualTo: (NSUInteger)index by: (NSInteger)delta
 {
-	const NSUInteger externalCount = [_externalIndexToBackingIndex count];
+	const NSUInteger externalCount = _externalIndexToBackingIndex.count;
 	for (NSUInteger i = 0; i < externalCount; i++)
 	{
 		const NSUInteger backingI  = (NSUInteger)[_externalIndexToBackingIndex pointerAtIndex: i];
@@ -188,7 +188,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (NSUInteger)count
 {
-	return [_externalIndexToBackingIndex count];
+	return _externalIndexToBackingIndex.count;
 }
 
 - (NSUInteger)backingIndex: (NSUInteger)index
@@ -217,10 +217,10 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	
     // NSPointerArray on 10.7 doesn't allow inserting at the end using index == count, so
     // call addPointer in that case as a workaround.
-    if (index == [_externalIndexToBackingIndex count])
+    if (index == _externalIndexToBackingIndex.count)
     {
 		// insert at end
-		[_externalIndexToBackingIndex addPointer: (void *)[_backing count]];
+		[_externalIndexToBackingIndex addPointer: (void *)_backing.count];
 		[_backing addPointer: (__bridge void *)anObject];
     }
     else
@@ -528,7 +528,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (NSUInteger)count
 {
-	return [_backing count] - [_deadReferences count];
+	return _backing.count - _deadReferences.count;
 }
 
 - (id)member: (id)anObject
@@ -653,7 +653,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (NSUInteger)count
 {
-	return [_backing count] - [_deadKeys count];
+	return _backing.count - _deadKeys.count;
 }
 
 - (id)objectForKey: (id)key

--- a/Tests/Core/TestObject.m
+++ b/Tests/Core/TestObject.m
@@ -352,6 +352,32 @@
 	UKRaisesException([contentsDesc setOrdered: NO]);
 }
 
+- (void) testDidChangeValueForWrongProperty
+{
+	COObjectGraphContext *objectGraphContext = [COObjectGraphContext objectGraphContext];
+	OutlineItem *object = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
+	
+	[object willChangeValueForProperty: @"label"];
+	UKRaisesException([object didChangeValueForProperty: @"contents"]);
+}
+
+- (void) testUnpairedDidChangeValueForProperty
+{
+	COObjectGraphContext *objectGraphContext = [COObjectGraphContext objectGraphContext];
+	OutlineItem *object = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
+	
+	UKRaisesException([object didChangeValueForProperty: @"contents"]);
+}
+
+- (void) testEmptyDidChangeValueForProperty
+{
+	COObjectGraphContext *objectGraphContext = [COObjectGraphContext objectGraphContext];
+	OutlineItem *object = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
+	
+	[object willChangeValueForProperty: @"label"];
+	UKDoesNotRaiseException([object didChangeValueForProperty: @"label"]);
+}
+
 @end
 
 

--- a/Tests/Core/TestObject.m
+++ b/Tests/Core/TestObject.m
@@ -382,3 +382,68 @@
 }
 
 @end
+
+#pragma mark - Test Insertion Hint
+
+@interface OutlineItem_InsertObjectAtIndexHint_Mock : OutlineItem
+@property (nonatomic, readwrite, strong) NSMutableArray *insertObjectArgumentsForCalls;
+@end
+
+@implementation OutlineItem_InsertObjectAtIndexHint_Mock
+
+@synthesize insertObjectArgumentsForCalls;
+
+-(void)insertObject:(id)object atIndex:(NSUInteger)index hint:(id)hint
+{
+	[super insertObject:object atIndex:index hint:hint];
+	
+	if (nil == insertObjectArgumentsForCalls)
+		insertObjectArgumentsForCalls = [NSMutableArray array];
+
+	[insertObjectArgumentsForCalls addObject: @{ @"object" : object,
+												 @"index" : @(index),
+												 @"hint" : hint ? hint : [NSNull null]}];
+}
+
+@end
+
+@interface TestObjectInsertionHint : EditingContextTestCase <UKTest>
+{
+	COObjectGraphContext *objectGraphContext;
+	OutlineItem_InsertObjectAtIndexHint_Mock *parent;
+	OutlineItem *other;
+}
+
+@end
+
+@implementation TestObjectInsertionHint
+
+- (id)init
+{
+	SUPERINIT;
+	objectGraphContext = [COObjectGraphContext objectGraphContext];
+
+	parent = [[OutlineItem_InsertObjectAtIndexHint_Mock alloc]
+				initWithObjectGraphContext: objectGraphContext];
+	
+	// N.B.: Not added to parent yet.
+	other = [[OutlineItem alloc] initWithObjectGraphContext: objectGraphContext];
+
+	return self;
+}
+
+- (void) testAddObject
+{
+	UKNil(parent.insertObjectArgumentsForCalls);
+	[parent addObject: other];
+	UKIntsEqual(1, [parent.insertObjectArgumentsForCalls count]);
+	
+	// Check the arguments that were passed to -insertObject:atIndex:hint:
+	NSDictionary *args = parent.insertObjectArgumentsForCalls[0];
+	UKObjectsSame(other, args[@"object"]);
+	UKObjectsEqual(@(ETUndeterminedIndex), args[@"index"]);
+	UKObjectsEqual([NSNull null], args[@"hint"]);
+}
+
+@end
+

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -459,6 +459,24 @@
 	UKTrue(objectDealloced);
 }
 
+- (void) testDisallowsDuplicates
+{
+	[array addObject: @"a"];
+	[array addObject: @"b"];
+	[array addObject: [NSString stringWithFormat: @"a"]];
+	UKObjectsEqual(A(@"a", @"b"), array);
+}
+
+- (void) testAllowsReinsertion
+{
+	[array addObject: @"a"];
+	UKObjectsEqual(A(@"a"), array);
+	[array removeObject: @"a"];
+	UKObjectsEqual(A(), array);
+	[array addObject: @"a"];
+	UKObjectsEqual(A(@"a"), array);
+}
+
 @end
 
 #pragma mark - TestUnsafeRetainedMutableSet
@@ -496,6 +514,24 @@
 	}
 	
 	UKTrue(objectDealloced);
+}
+
+- (void) testDisallowsDuplicates
+{
+	[set addObject: @"a"];
+	[set addObject: @"b"];
+	[set addObject: [NSString stringWithFormat: @"a"]];
+	UKObjectsEqual(S(@"a", @"b"), set);
+}
+
+- (void) testAllowsReinsertion
+{
+	[set addObject: @"a"];
+	UKObjectsEqual(S(@"a"), set);
+	[set removeObject: @"a"];
+	UKObjectsEqual(S(), set);
+	[set addObject: @"a"];
+	UKObjectsEqual(S(@"a"), set);
 }
 
 @end

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -397,3 +397,105 @@
 }
 
 @end
+
+#pragma mark - TestUnsafeRetainedMutableArray
+
+@interface DoOnDealloc : NSObject
+{
+	void (^doOnDeallocBlock)();
+}
+@end
+
+@implementation DoOnDealloc
+
+-(instancetype)initWithBlock:(void (^)())aDoOnDeallocBlock;
+{
+	SUPERINIT;
+	doOnDeallocBlock = aDoOnDeallocBlock;
+	return self;
+}
+
+- (void)dealloc
+{
+	doOnDeallocBlock();
+}
+
+@end
+
+
+
+@interface TestUnsafeRetainedMutableArray : NSObject <UKTest>
+{
+	COUnsafeRetainedMutableArray *array;
+}
+
+@end
+
+@implementation TestUnsafeRetainedMutableArray
+
+- (id)init
+{
+	SUPERINIT;
+	array = [COUnsafeRetainedMutableArray new];
+	array.mutable = YES;
+	return self;
+}
+
+- (void) testDoesNotRetain
+{
+	__block BOOL objectDealloced = NO;
+	
+	@autoreleasepool {
+		DoOnDealloc *foo = [[DoOnDealloc alloc] initWithBlock: ^() {
+			// This executes when this object is being deallocated
+			objectDealloced = YES;
+		}];
+		
+		[array addObject: foo];
+		UKObjectsSame(foo, array[0]);
+		UKFalse(objectDealloced);
+	}
+	
+	UKTrue(objectDealloced);
+}
+
+@end
+
+#pragma mark - TestUnsafeRetainedMutableSet
+
+@interface TestUnsafeRetainedMutableSet : NSObject <UKTest>
+{
+	COUnsafeRetainedMutableSet *set;
+}
+
+@end
+
+@implementation TestUnsafeRetainedMutableSet
+
+- (id)init
+{
+	SUPERINIT;
+	set = [COUnsafeRetainedMutableSet new];
+	set.mutable = YES;
+	return self;
+}
+
+- (void) testDoesNotRetain
+{
+	__block BOOL objectDealloced = NO;
+	
+	@autoreleasepool {
+		DoOnDealloc *foo = [[DoOnDealloc alloc] initWithBlock: ^() {
+			// This executes when this object is being deallocated
+			objectDealloced = YES;
+		}];
+		
+		[set addObject: foo];
+		UKIntsEqual(1, [set count]);
+		UKFalse(objectDealloced);
+	}
+	
+	UKTrue(objectDealloced);
+}
+
+@end

--- a/Tests/Relationship/TestOrderedCompositeRelationship.m
+++ b/Tests/Relationship/TestOrderedCompositeRelationship.m
@@ -123,6 +123,18 @@
 			|| [@[child1, child2] isEqual: parent.contents]));
 }
 
+- (void) testDuplicatesAutomaticallyRemovedOnAddObject
+{
+	parent.contents = @[child1, child2];
+	[parent addObject: child1];
+	UKObjectsEqual(A(child1, child2), parent.contents);
+	[parent addObject: child2];
+	UKObjectsEqual(A(child1, child2), parent.contents);
+	
+	// Verify at the store item level too
+	UKObjectsEqual(A(child1.UUID, child2.UUID), [[parent storeItem] valueForAttribute: @"contents"]);
+}
+
 - (void) testIllegalDirectModificationOfCollection
 {
 	// Test that an exception is raised when modifying when we last set the array using a setter


### PR DESCRIPTION
The first 4 commits are just adding tests/benchmarks, the next 4 have the optimizations:

* rewrote handling of tombstones in `COMutableArray` to be faster. `-count` and `-objectAtIndex:` are now trivial, O(1).
* make `COUnsafeRetainedMutableArray` automatically remove duplicates, like NSOrderedSet. This lets us avoid the slow `-[COObject removeDuplicatesInValue:propertyDescription:]` every time a collection is modified.
* make a fast path version of `-commonDidChangeValueForProperty:` that just handles the updated elements of the collection. It's called: `-commonDidChangeValueForProperty:atIndexes:withObjects:mutationKind:`.

The benchmark I measured this with is TestLargeOrderedRelationsip (added in the first commit in this branch).

The benchmark incrementally adds 1000 OutlineItems to an OutlineItem with -addObject, then times various calls on `parent.contents` like `-count` and for/in enumeration.
Rewriting the tombstone code in COMutableArray made  `-count` ~30x faster when called on a collection with 1000 elements, and for/in enumeration ~5x faster.

The slowest part originally was building the collection of 1000 outline items by calling -addObject: in a loop, which was taking 10 seconds! Adding the fast path for `-commonDidChangeValueForProperty:` brought this down to 0.25 seconds (still kind of bad, but tolerable.)

(edit: all benchmarks re-run with 17aefef )
Before: 
```
2015-09-11 13:16:45.358 BenchmarkCoreObject[79618:1863789] 92.141032 us per iteration for 'Create OutlineItem and add to an NSMutableArray with -addObject:'
2015-09-11 13:16:56.758 BenchmarkCoreObject[79618:1863789] 11.399381 ms per iteration for 'Add OutlineItem to an OutlineItem with -addObject:'
2015-09-11 13:16:56.758 BenchmarkCoreObject[79618:1863789] 0.133991 us per iteration for 'Add OutlineItem to an NSMutableArray with -addObject:'
2015-09-11 13:16:56.759 BenchmarkCoreObject[79618:1863789] 0.459015 us per iteration for '-count on CoreObject array with 1000 elements'
2015-09-11 13:16:56.763 BenchmarkCoreObject[79618:1863789] 0.009000 us per iteration for '-count on NSArray with 1000 elements'
2015-09-11 13:17:00.693 BenchmarkCoreObject[79618:1863789] 3.930156 ms per iteration for 'for/in loop on CoreObject array with 1000 elements'
2015-09-11 13:17:00.698 BenchmarkCoreObject[79618:1863789] 4.337966 us per iteration for 'for/in loop on NSArray with 1000 elements'
```
After:
```
2015-09-11 13:15:34.698 BenchmarkCoreObject[79367:1862903] 155.786991 us per iteration for 'Create OutlineItem and add to an NSMutableArray with -addObject:'
2015-09-11 13:15:34.829 BenchmarkCoreObject[79367:1862903] 130.748034 us per iteration for 'Add OutlineItem to an OutlineItem with -addObject:'
2015-09-11 13:15:34.830 BenchmarkCoreObject[79367:1862903] 0.187993 us per iteration for 'Add OutlineItem to an NSMutableArray with -addObject:'
2015-09-11 13:15:34.830 BenchmarkCoreObject[79367:1862903] 0.014007 us per iteration for '-count on CoreObject array with 1000 elements'
2015-09-11 13:15:34.830 BenchmarkCoreObject[79367:1862903] 0.009000 us per iteration for '-count on NSArray with 1000 elements'
2015-09-11 13:15:34.970 BenchmarkCoreObject[79367:1862903] 139.808953 us per iteration for 'for/in loop on CoreObject array with 1000 elements'
2015-09-11 13:15:34.974 BenchmarkCoreObject[79367:1862903] 4.342973 us per iteration for 'for/in loop on NSArray with 1000 elements'
```

Edit: after removing relationship snapshotting:
```
2015-09-11 13:14:07.742 BenchmarkCoreObject[78716:1861487] 126.591027 us per iteration for 'Create OutlineItem and add to an NSMutableArray with -addObject:'
2015-09-11 13:14:07.791 BenchmarkCoreObject[78716:1861487] 48.901021 us per iteration for 'Add OutlineItem to an OutlineItem with -addObject:'
2015-09-11 13:14:07.792 BenchmarkCoreObject[78716:1861487] 0.321984 us per iteration for 'Add OutlineItem to an NSMutableArray with -addObject:'
2015-09-11 13:14:07.792 BenchmarkCoreObject[78716:1861487] 0.021994 us per iteration for '-count on CoreObject array with 1000 elements'
2015-09-11 13:14:07.793 BenchmarkCoreObject[78716:1861487] 0.009000 us per iteration for '-count on NSArray with 1000 elements'
2015-09-11 13:14:07.951 BenchmarkCoreObject[78716:1861487] 157.586992 us per iteration for 'for/in loop on CoreObject array with 1000 elements'
2015-09-11 13:14:07.955 BenchmarkCoreObject[78716:1861487] 4.539967 us per iteration for 'for/in loop on NSArray with 1000 elements'
```