### PR TITLE
Store/COSQLiteStorePersistentRootBackingStore.m: Change deletion semantics for -deleteRevids:.

### DIFF
--- a/CoreObject.xcodeproj/project.pbxproj
+++ b/CoreObject.xcodeproj/project.pbxproj
@@ -772,6 +772,7 @@
 		66EEB2B7186D3CBA003695E6 /* TestItemGraph.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EEB2B6186D3CBA003695E6 /* TestItemGraph.m */; };
 		66EF4276186251A800E15C59 /* TestDiffCAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EF4275186251A800E15C59 /* TestDiffCAPI.m */; };
 		66F1985919667265001EAEB0 /* TestMetamodelCornerCases.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F1985819667265001EAEB0 /* TestMetamodelCornerCases.m */; };
+		66F1BE841BB1D9C900CC9E23 /* TestSQLiteBackingStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F1BE831BB1D9C900CC9E23 /* TestSQLiteBackingStore.m */; settings = {ASSET_TAGS = (); }; };
 		66FB15DA17AB31F6003BFC9B /* COObject+Accessors.m in Sources */ = {isa = PBXBuildFile; fileRef = 66FB15D817AB31F5003BFC9B /* COObject+Accessors.m */; };
 		66FD348B1830B84C00898381 /* COSynchronizerJSONServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 66FD34891830B84C00898381 /* COSynchronizerJSONServer.m */; };
 		66FD348E1830BB3800898381 /* COSynchronizerJSONClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 66FD348C1830BB3800898381 /* COSynchronizerJSONClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1420,6 +1421,7 @@
 		66EEB2B6186D3CBA003695E6 /* TestItemGraph.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestItemGraph.m; sourceTree = "<group>"; };
 		66EF4275186251A800E15C59 /* TestDiffCAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestDiffCAPI.m; sourceTree = "<group>"; };
 		66F1985819667265001EAEB0 /* TestMetamodelCornerCases.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestMetamodelCornerCases.m; sourceTree = "<group>"; };
+		66F1BE831BB1D9C900CC9E23 /* TestSQLiteBackingStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestSQLiteBackingStore.m; sourceTree = "<group>"; };
 		66FB15D817AB31F5003BFC9B /* COObject+Accessors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "COObject+Accessors.m"; path = "Core/COObject+Accessors.m"; sourceTree = "<group>"; };
 		66FD34881830B84C00898381 /* COSynchronizerJSONServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COSynchronizerJSONServer.h; path = Synchronization/COSynchronizerJSONServer.h; sourceTree = "<group>"; };
 		66FD34891830B84C00898381 /* COSynchronizerJSONServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = COSynchronizerJSONServer.m; path = Synchronization/COSynchronizerJSONServer.m; sourceTree = "<group>"; };
@@ -2230,6 +2232,7 @@
 				66E40D451836D08D00E5B4A7 /* TestSQLiteStoreMultiPersistentRoots.m */,
 				66E40D461836D08D00E5B4A7 /* TestSQLiteStoreSharedPersistentRoots.m */,
 				664F27A3188F4E9600DF36FC /* TestSQLiteStoreRevisionInfos.m */,
+				66F1BE831BB1D9C900CC9E23 /* TestSQLiteBackingStore.m */,
 			);
 			name = Store;
 			path = Tests/Store;
@@ -3603,6 +3606,7 @@
 				66E40D591836D08D00E5B4A7 /* TestCOObjectSynthesizedAccessors.m in Sources */,
 				66E40D721836D08D00E5B4A7 /* TestSynchronizer.m in Sources */,
 				66E40D571836D08D00E5B4A7 /* TestBranch.m in Sources */,
+				66F1BE841BB1D9C900CC9E23 /* TestSQLiteBackingStore.m in Sources */,
 				6699DDA7184887C30003E803 /* TestOrderedCompositeRelationship.m in Sources */,
 				66E40D681836D08D00E5B4A7 /* TestCollection.m in Sources */,
 				66E40D751836D08E00E5B4A7 /* TestCustomTrack.m in Sources */,

--- a/StorageDataModel/COItemGraph.h
+++ b/StorageDataModel/COItemGraph.h
@@ -120,6 +120,10 @@
  * receiver.
  */
 - (void) addItemGraph: (id<COItemGraph>)aGraph;
+/**
+ * Removes all unreachable items.
+ */
+- (void)removeUnreachableItems;
 
 @end
 

--- a/StorageDataModel/COItemGraph.m
+++ b/StorageDataModel/COItemGraph.m
@@ -145,6 +145,16 @@
     }
 }
 
+- (void)removeUnreachableItems
+{
+	NSSet *reachableUUIDs = COItemGraphReachableUUIDs(self);
+
+	NSMutableSet *unreachableUUIDs = [NSMutableSet setWithArray: [itemForUUID_ allKeys]];
+	[unreachableUUIDs minusSet: reachableUUIDs];
+	
+	[itemForUUID_ removeObjectsForKeys: [unreachableUUIDs allObjects]];
+}
+
 @end
 
 
@@ -330,6 +340,12 @@ static BOOL COItemGraphEqualToItemGraphComparingItemUUID(id<COItemGraph> first, 
 {
     COItem *my = [first itemForUUID: aUUID];
     COItem *other = [second itemForUUID: aUUID];
+	if (my == nil && other == nil)
+	{
+		// both item graphs are missing the same item
+		return YES;
+	}
+	
     if (![my isEqual: other])
     {
         return NO;

--- a/StorageDataModel/COItemGraph.m
+++ b/StorageDataModel/COItemGraph.m
@@ -149,10 +149,10 @@
 {
 	NSSet *reachableUUIDs = COItemGraphReachableUUIDs(self);
 
-	NSMutableSet *unreachableUUIDs = [NSMutableSet setWithArray: [itemForUUID_ allKeys]];
+	NSMutableSet *unreachableUUIDs = [NSMutableSet setWithArray: itemForUUID_.allKeys];
 	[unreachableUUIDs minusSet: reachableUUIDs];
 	
-	[itemForUUID_ removeObjectsForKeys: [unreachableUUIDs allObjects]];
+	[itemForUUID_ removeObjectsForKeys: unreachableUUIDs.allObjects];
 }
 
 @end

--- a/Tests/Store/TestSQLiteBackingStore.m
+++ b/Tests/Store/TestSQLiteBackingStore.m
@@ -114,16 +114,16 @@
 
 - (void) commitWithGraph: (COItemGraph *)graph parent: (int64_t)parentRevid
 {
-	ETUUID *revUUID = [ETUUID UUID];
-	BOOL ok = [backing writeItemGraph: graph
-						 revisionUUID: revUUID
-						 withMetadata: @{}
-						   withParent: parentRevid
-					  withMergeParent: -1
-						   branchUUID: branchUUID
-				   persistentrootUUID: prootUUID
-								error: NULL];
-	ETAssert(ok);
+    ETUUID *revUUID = [ETUUID UUID];
+    BOOL ok = [backing writeItemGraph: graph
+                         revisionUUID: revUUID
+                         withMetadata: @{}
+                           withParent: parentRevid
+                      withMergeParent: -1
+                           branchUUID: branchUUID
+                   persistentrootUUID: prootUUID
+                                error: NULL];
+    ETAssert(ok);
 }
 
 - (COItemGraph *) itemGraphForRevid: (int64_t)revid
@@ -138,7 +138,7 @@
 						   
 	for (NSData *blob in [store.database arrayForQuery: [NSString stringWithFormat: @"SELECT contents FROM %@", [backing tableName]]])
 	{
-		NSRange rangeOfPassword = [blob rangeOfData:passwordBytes options:0 range: NSMakeRange(0, [blob length])];
+		NSRange rangeOfPassword = [blob rangeOfData: passwordBytes options: 0 range: NSMakeRange(0, blob.length)];
 		if (rangeOfPassword.location != NSNotFound)
 		{
 			return YES;

--- a/Tests/Store/TestSQLiteBackingStore.m
+++ b/Tests/Store/TestSQLiteBackingStore.m
@@ -1,0 +1,180 @@
+/*
+	Copyright (C) 2015 Eric Wasylishen
+ 
+	Date:  September 2015
+	License:  MIT  (see COPYING)
+ */
+
+#import "TestCommon.h"
+#import "COItem.h"
+#import "COSQLiteStorePersistentRootBackingStore.h"
+#import "FMDatabaseAdditions.h"
+
+#pragma mark - MockStore
+
+@interface MockStore : NSObject
+@property (nonatomic, assign) NSUInteger maxNumberOfDeltaCommits;
+@property (nonatomic, strong) FMDatabase *database;
+@end
+
+@implementation MockStore
+
+@synthesize maxNumberOfDeltaCommits, database;
+
+- (instancetype) init
+{
+	SUPERINIT;
+	self.maxNumberOfDeltaCommits = 4;
+	// Create an in-memory DB. See https://www.sqlite.org/c3ref/open.html
+	self.database = [FMDatabase databaseWithPath: @":memory:"];
+	ETAssert([self.database open]);
+	return self;
+}
+
+@end
+
+#pragma mark - COSQLiteStorePersistentRootBackingStore (Private)
+
+@interface COSQLiteStorePersistentRootBackingStore (Private)
+
+- (NSString *) tableName;
+
+@end
+
+#pragma mark - TestSQLiteBackingStore
+
+@interface TestSQLiteBackingStore : TestCase <UKTest>
+{
+	MockStore *store;
+	ETUUID *prootUUID;
+	ETUUID *branchUUID;
+	COSQLiteStorePersistentRootBackingStore *backing;
+	ETUUID *rootitemUUID;
+	ETUUID *childitemUUID;
+}
+@end
+
+@implementation TestSQLiteBackingStore
+
+#pragma mark Sample Item Graph Creation
+
+- (COItem *)parentItem: (NSString*)name referenceChildren: (BOOL)addChildRefs
+{
+	COMutableItem *rootitem = [[COMutableItem alloc] initWithUUID: rootitemUUID];
+	[rootitem setValue: name forAttribute: @"name" type: kCOTypeString];
+	if (addChildRefs)
+	{
+		[rootitem setValue: @[childitemUUID] forAttribute: @"contents" type: COTypeMakeArrayOf(kCOTypeCompositeReference)];
+	}
+	return rootitem;
+}
+
+- (COItem *)childItem: (NSString *)name
+{
+	COMutableItem *childitem = [[COMutableItem alloc] initWithUUID: childitemUUID];
+	[childitem setValue: name forAttribute: @"name" type: kCOTypeString];
+	return childitem;
+}
+
+- (COItemGraph *)graphWithParent: (NSString*)name
+{
+	return [[COItemGraph alloc] initWithItems: @[[self parentItem: name referenceChildren: NO]]
+								 rootItemUUID: rootitemUUID];
+}
+
+- (COItemGraph *)graphWithParent: (NSString*)name child: (NSString *)childlabel
+{
+	return [[COItemGraph alloc] initWithItems: @[[self parentItem: name referenceChildren: YES],
+												 [self childItem: childlabel]]
+								 rootItemUUID: rootitemUUID];
+}
+
+- (COItemGraph *)graphWithChild: (NSString *)childlabel
+{
+	return [[COItemGraph alloc] initWithItems: @[[self childItem: childlabel]]
+								 rootItemUUID: rootitemUUID];
+}
+
+#pragma mark Test Methods
+
+- (instancetype) init
+{
+	SUPERINIT;
+	store = [MockStore new];
+	prootUUID = [ETUUID UUID];
+	branchUUID = [ETUUID UUID];
+	backing = [[COSQLiteStorePersistentRootBackingStore alloc] initWithPersistentRootUUID: prootUUID
+																					store: (COSQLiteStore *)store
+																			   useStoreDB: YES
+																					error: NULL];
+	rootitemUUID = [ETUUID UUID];
+	childitemUUID = [ETUUID UUID];
+	return self;
+}
+
+- (void) commitWithGraph: (COItemGraph *)graph parent: (int64_t)parentRevid
+{
+	ETUUID *revUUID = [ETUUID UUID];
+	BOOL ok = [backing writeItemGraph: graph
+						 revisionUUID: revUUID
+						 withMetadata: @{}
+						   withParent: parentRevid
+					  withMergeParent: -1
+						   branchUUID: branchUUID
+				   persistentrootUUID: prootUUID
+								error: NULL];
+	ETAssert(ok);
+}
+
+- (COItemGraph *) itemGraphForRevid: (int64_t)revid
+{
+	ETAssert(revid != -1);
+	return [backing itemGraphForRevid: revid];
+}
+
+- (BOOL) storeHasPassword
+{
+	NSData *passwordBytes = [@"password" dataUsingEncoding: NSUTF8StringEncoding];
+						   
+	for (NSData *blob in [store.database arrayForQuery: [NSString stringWithFormat: @"SELECT contents FROM %@", [backing tableName]]])
+	{
+		NSRange rangeOfPassword = [blob rangeOfData:passwordBytes options:0 range: NSMakeRange(0, [blob length])];
+		if (rangeOfPassword.location != NSNotFound)
+		{
+			return YES;
+		}
+	}
+	return NO;
+}
+
+- (void) testDeletion
+{
+	COItemGraph *rootgraph = [self graphWithParent: @"parent"];							// revid 0
+	COItemGraph *branch1_a = [self graphWithParent: @"parent 1_a" child: @"password!"];	// revid 1
+	COItemGraph *branch2_a = [self graphWithParent: @"parent 2_a" child: @"child 2_a"];	// revid 2
+	COItemGraph *branch1_b = [self graphWithParent: @"parent 1_b"];						// revid 3
+	
+	[self commitWithGraph: rootgraph parent: -1];	// revid 0
+	[self commitWithGraph: branch1_a parent: 0];	// revid 1
+	[self commitWithGraph: branch2_a parent: 0];	// revid 2
+	[self commitWithGraph: branch1_b parent: 1];	// revid 3
+	
+	UKObjectsEqual(rootgraph, [backing itemGraphForRevid: 0]);
+	UKObjectsEqual(branch1_a, [backing itemGraphForRevid: 1]);
+	UKObjectsEqual(branch2_a, [backing itemGraphForRevid: 2]);
+	UKObjectsEqual(branch1_b, [backing itemGraphForRevid: 3]);
+	
+	UKTrue([self storeHasPassword]);
+	
+	// now delete revid 1, to remove "password!" from the store
+	
+	[backing deleteRevids: INDEXSET(1)];
+	UKFalse([self storeHasPassword]);
+	
+	UKObjectsEqual(rootgraph, [backing itemGraphForRevid: 0]);
+	UKNil([backing itemGraphForRevid: 1]);
+	UKObjectsEqual(branch2_a, [backing itemGraphForRevid: 2]);
+	UKObjectsEqual(branch1_b, [backing itemGraphForRevid: 3]);
+}
+
+@end


### PR DESCRIPTION
Now all given revids are guaranteed to be deleted from the backing store.
If there any child revisions of the revisions being deleted which are deltas, turns them into full snapshots so they aren't corrupted.

The test case simulates an example David posted where you want to make sure a password is deleted from the store.

Tests/Store/TestSQLiteBackingStore.m: Start a backing store test case