### PR TITLE
COObjectGraphContext: properly discard objects when deallocated.

### DIFF
--- a/Core/COObject+RelationshipCache.m
+++ b/Core/COObject+RelationshipCache.m
@@ -61,6 +61,12 @@ static BOOL isPersistentCoreObjectReferencePropertyDescription(ETPropertyDescrip
 		}
 		else
 		{
+            if (![obj isKindOfClass: [COObject class]])
+            {
+                NSLog(@"%@: Warning, ignoring non-COObject instance %@ in %@ of %@", NSStringFromSelector(_cmd), obj, aProperty.name, self);
+                return;
+            }
+            
 			[[obj incomingRelationshipCache] removeReferencesForPropertyInSource: [aProperty name]
 																	sourceObject: self];
 		}

--- a/Core/COObject+RelationshipCache.m
+++ b/Core/COObject+RelationshipCache.m
@@ -63,6 +63,12 @@ static BOOL isPersistentCoreObjectReferencePropertyDescription(ETPropertyDescrip
 		{
             if (![obj isKindOfClass: [COObject class]])
             {
+                // After inserting an illegal type of object into a collection that fails validation
+                // (throwing an exception), we don't currently remove the invalid object.
+                // (see -testNullDisallowedInCollection in the test suite.)
+                // This is a hack so that -[COObjectGraphContext dealloc] can complete
+                // without throwing an exception below, because the invalid object doesn't respond
+                // to -incomingRelationshipCache.
                 NSLog(@"%@: Warning, ignoring non-COObject instance %@ in %@ of %@", NSStringFromSelector(_cmd), obj, aProperty.name, self);
                 return;
             }

--- a/Core/COObject+RelationshipCache.m
+++ b/Core/COObject+RelationshipCache.m
@@ -61,18 +61,18 @@ static BOOL isPersistentCoreObjectReferencePropertyDescription(ETPropertyDescrip
 		}
 		else
 		{
-            if (![obj isKindOfClass: [COObject class]])
-            {
-                // After inserting an illegal type of object into a collection that fails validation
-                // (throwing an exception), we don't currently remove the invalid object.
-                // (see -testNullDisallowedInCollection in the test suite.)
-                // This is a hack so that -[COObjectGraphContext dealloc] can complete
-                // without throwing an exception below, because the invalid object doesn't respond
-                // to -incomingRelationshipCache.
-                NSLog(@"%@ - note - ignoring non-COObject instance %@ in %@ of %@", NSStringFromSelector(_cmd), obj, aProperty.name, self);
-                return;
-            }
-            
+			if (![obj isKindOfClass: [COObject class]])
+			{
+				// After inserting an illegal type of object into a collection that fails validation
+				// (throwing an exception), we don't currently remove the invalid object.
+				// (see -testNullDisallowedInCollection in the test suite.)
+				// This is a hack so that -[COObjectGraphContext dealloc] can complete
+				// without throwing an exception below, because the invalid object doesn't respond
+				// to -incomingRelationshipCache.
+				NSLog(@"%@ - note - ignoring non-COObject instance %@ in %@ of %@", NSStringFromSelector(_cmd), obj, aProperty.name, self);
+				return;
+			}
+			
 			[[obj incomingRelationshipCache] removeReferencesForPropertyInSource: [aProperty name]
 																	sourceObject: self];
 		}

--- a/Core/COObject+RelationshipCache.m
+++ b/Core/COObject+RelationshipCache.m
@@ -69,7 +69,7 @@ static BOOL isPersistentCoreObjectReferencePropertyDescription(ETPropertyDescrip
                 // This is a hack so that -[COObjectGraphContext dealloc] can complete
                 // without throwing an exception below, because the invalid object doesn't respond
                 // to -incomingRelationshipCache.
-                NSLog(@"%@: Warning, ignoring non-COObject instance %@ in %@ of %@", NSStringFromSelector(_cmd), obj, aProperty.name, self);
+                NSLog(@"%@ - note - ignoring non-COObject instance %@ in %@ of %@", NSStringFromSelector(_cmd), obj, aProperty.name, self);
                 return;
             }
             

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -540,6 +540,13 @@ See +[NSObject typePrefix]. */
 
 - (BOOL)isEditingContextValidForObject: (COObject *)value
 {
+    if (value != nil && ![value isKindOfClass: [COObject class]])
+    {
+        // This can happen in -testNullDisallowedInCollection which leaves [NSNull null] instances
+        // in a collection.
+        return NO;
+    }
+    
 	COEditingContext *valueEditingContext = [[value persistentRoot] parentContext];
 	COEditingContext *currentEditingContext = [[self persistentRoot] parentContext];
 	BOOL involvesTransientObject = (valueEditingContext == nil || currentEditingContext == nil);

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1876,6 +1876,8 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 						updated = YES;
 					}
 					[array replaceReferenceAtIndex: i withReference: replacement];
+                    // Make sure it wasn't wrongly rejected as a duplicate, etc.
+                    ETAssert([array referenceAtIndex: i] == replacement);
 				}
 			}
 			array.mutable = NO;
@@ -1894,6 +1896,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 				}
 				[set removeReference: object];
 				[set addReference: replacement];
+                ETAssert([set containsReference: replacement]);
 			}
 			set.mutable = NO;
 		}
@@ -1904,6 +1907,8 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 			// FIXME: We should call -setValue:forStorageKey here.
 			[self willChangeValueForProperty: key];
 			[self setValue: replacement forVariableStorageKey: key];
+            // TODO: Would be nice to have an assertion here
+            //ETAssert([self valueForVariableStorageKey: key] == replacement);
 			updated = YES;
 		}
 

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -1716,6 +1716,18 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 {
     [self removeCachedOutgoingRelationships];
 	
+    // If there are any pointers in other object graph contexts to self, replace them
+    // with [COPath brokenPath]. This shouldn't normally happen, but does when deallocating
+    // one COObjectGraphContext but not another that has pointers to the first.
+    for (COCachedRelationship *cacheEntry in [_incomingRelationshipCache.allEntries copy])
+    {
+        if (cacheEntry.sourceObject.objectGraphContext != self.objectGraphContext)
+        {
+            [cacheEntry.sourceObject.objectGraphContext replaceObject: self
+                                                           withObject: (id)[COPath brokenPath]];
+        }
+    }
+    
 	/* For dead outgoing univalued relationship, the property value is nil and 
 	   not a COPath, so -removeCachedOutgoingRelationships does nothing, and 
 	   we have to remove the receiver manually.

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -540,13 +540,13 @@ See +[NSObject typePrefix]. */
 
 - (BOOL)isEditingContextValidForObject: (COObject *)value
 {
-    if (value != nil && ![value isKindOfClass: [COObject class]])
-    {
-        // This can happen in -testNullDisallowedInCollection which leaves [NSNull null] instances
-        // in a collection.
-        return NO;
-    }
-    
+	if (value != nil && ![value isKindOfClass: [COObject class]])
+	{
+		// This can happen in -testNullDisallowedInCollection which leaves [NSNull null] instances
+		// in a collection.
+		return NO;
+	}
+	
 	COEditingContext *valueEditingContext = [[value persistentRoot] parentContext];
 	COEditingContext *currentEditingContext = [[self persistentRoot] parentContext];
 	BOOL involvesTransientObject = (valueEditingContext == nil || currentEditingContext == nil);
@@ -1716,18 +1716,18 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 {
     [self removeCachedOutgoingRelationships];
 	
-    // If there are any pointers in other object graph contexts to self, replace them
-    // with [COPath brokenPath]. This shouldn't normally happen, but does when deallocating
-    // one COObjectGraphContext but not another that has pointers to the first.
-    for (COCachedRelationship *cacheEntry in [_incomingRelationshipCache.allEntries copy])
-    {
-        if (cacheEntry.sourceObject.objectGraphContext != self.objectGraphContext)
-        {
-            [cacheEntry.sourceObject.objectGraphContext replaceObject: self
-                                                           withObject: (id)[COPath brokenPath]];
-        }
-    }
-    
+	// If there are any pointers in other object graph contexts to self, replace them
+	// with [COPath brokenPath]. This shouldn't normally happen, but does when deallocating
+	// one COObjectGraphContext but not another that has pointers to the first.
+	for (COCachedRelationship *cacheEntry in [_incomingRelationshipCache.allEntries copy])
+	{
+		if (cacheEntry.sourceObject.objectGraphContext != self.objectGraphContext)
+		{
+			[cacheEntry.sourceObject.objectGraphContext replaceObject: self
+														   withObject: (id)[COPath brokenPath]];
+		}
+	}
+	
 	/* For dead outgoing univalued relationship, the property value is nil and 
 	   not a COPath, so -removeCachedOutgoingRelationships does nothing, and 
 	   we have to remove the receiver manually.
@@ -1895,8 +1895,8 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 						updated = YES;
 					}
 					[array replaceReferenceAtIndex: i withReference: replacement];
-                    // Make sure it wasn't wrongly rejected as a duplicate, etc.
-                    ETAssert([array referenceAtIndex: i] == replacement);
+					// Make sure it wasn't wrongly rejected as a duplicate, etc.
+					ETAssert([array referenceAtIndex: i] == replacement);
 				}
 			}
 			array.mutable = NO;
@@ -1915,7 +1915,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 				}
 				[set removeReference: object];
 				[set addReference: replacement];
-                ETAssert([set containsReference: replacement]);
+				ETAssert([set containsReference: replacement]);
 			}
 			set.mutable = NO;
 		}
@@ -1926,8 +1926,8 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 			// FIXME: We should call -setValue:forStorageKey here.
 			[self willChangeValueForProperty: key];
 			[self setValue: replacement forVariableStorageKey: key];
-            // TODO: Would be nice to have an assertion here
-            //ETAssert([self valueForVariableStorageKey: key] == replacement);
+			// TODO: Would be nice to have an assertion here
+			//ETAssert([self valueForVariableStorageKey: key] == replacement);
 			updated = YES;
 		}
 

--- a/Core/COObjectGraphContext.m
+++ b/Core/COObjectGraphContext.m
@@ -118,17 +118,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 
 - (void)dealloc
 {
-	// TODO: We should rather do [self discardObjectsWithUUIDs:  [NSSet setWithArray: _loadedObjects.allKeys]];
-	// This breaks currently due to deallocated outer object references
-	// (representing cross persistent root relationships), when multiple
-	// persistent roots are released at the same time.
-	COCrossPersistentRootDeadRelationshipCache *deadRelationshipCache =
-		self.editingContext.deadRelationshipCache;
-
-	for (ETUUID *uuid in _loadedObjects.allKeys)
-	{
-		[deadRelationshipCache removeReferringObject: [self loadedObjectForUUID: uuid]];
-	}
+	[self discardObjectsWithUUIDs:  [NSSet setWithArray: _loadedObjects.allKeys]];
 }
 
 - (NSString *)description

--- a/Core/CORelationshipCache.h
+++ b/Core/CORelationshipCache.h
@@ -14,12 +14,12 @@
 @interface COCachedRelationship : NSObject
 {
 @public
-    NSString *_targetProperty;
-    /**
-     * Weak reference.
-     */
-    COObject *__weak _sourceObject;
-    NSString *_sourceProperty;
+	NSString *_targetProperty;
+	/**
+	 * Weak reference.
+	 */
+	COObject *__weak _sourceObject;
+	NSString *_sourceProperty;
 }
 
 @property (nonatomic, readonly) NSDictionary *descriptionDictionary;

--- a/Core/CORelationshipCache.h
+++ b/Core/CORelationshipCache.h
@@ -11,6 +11,28 @@
 @class COObject;
 @class COItem;
 
+@interface COCachedRelationship : NSObject
+{
+@public
+    NSString *_targetProperty;
+    /**
+     * Weak reference.
+     */
+    COObject *__weak _sourceObject;
+    NSString *_sourceProperty;
+}
+
+@property (nonatomic, readonly) NSDictionary *descriptionDictionary;
+
+@property (readwrite, nonatomic, weak) COObject *sourceObject;
+@property (readwrite, nonatomic, copy) NSString *sourceProperty;
+@property (readwrite, nonatomic, copy) NSString *targetProperty;
+
+- (BOOL) isSourceObjectTrackingSpecificBranchForTargetObject: (COObject *)aTargetObject;
+- (BOOL)isSourceObjectBranchDeleted;
+
+@end
+
 /**
  * An instance of this class is owned by each COObject,
  * to cache incoming relationships for that object.
@@ -35,6 +57,8 @@
 - (COObject *) referringObjectForPropertyInTarget: (NSString *)aProperty;
 
 - (void) removeAllEntries;
+
+- (NSArray *) allEntries;
 
 - (void) removeReferencesForPropertyInSource: (NSString *)aTargetProperty
                                 sourceObject: (COObject *)anObject;

--- a/Core/CORelationshipCache.m
+++ b/Core/CORelationshipCache.m
@@ -15,28 +15,6 @@
 #import "COPersistentRoot.h"
 #import "COBranch.h"
 
-@interface COCachedRelationship : NSObject
-{
-@public
-    NSString *_targetProperty;
-    /**
-     * Weak reference.
-     */
-    COObject *__weak _sourceObject;
-    NSString *_sourceProperty;
-}
-
-@property (nonatomic, readonly) NSDictionary *descriptionDictionary;
-
-@property (readwrite, nonatomic, weak) COObject *sourceObject;
-@property (readwrite, nonatomic, copy) NSString *sourceProperty;
-@property (readwrite, nonatomic, copy) NSString *targetProperty;
-
-- (BOOL) isSourceObjectTrackingSpecificBranchForTargetObject: (COObject *)aTargetObject;
-- (BOOL)isSourceObjectBranchDeleted;
-
-@end
-
 @implementation COCachedRelationship
 
 @synthesize sourceObject = _sourceObject;
@@ -168,6 +146,11 @@
 - (void) removeAllEntries
 {
     [_cachedRelationships removeAllObjects];
+}
+
+- (NSArray *) allEntries
+{
+    return _cachedRelationships;
 }
 
 - (void) removeReferencesForPropertyInSource: (NSString *)aTargetProperty

--- a/Core/CORelationshipCache.m
+++ b/Core/CORelationshipCache.m
@@ -150,7 +150,7 @@
 
 - (NSArray *) allEntries
 {
-    return _cachedRelationships;
+	return _cachedRelationships;
 }
 
 - (void) removeReferencesForPropertyInSource: (NSString *)aTargetProperty

--- a/StorageDataModel/COPath.h
+++ b/StorageDataModel/COPath.h
@@ -42,6 +42,7 @@
 + (COPath *) pathWithPersistentRoot: (ETUUID *)aRoot
                              branch: (ETUUID*)aBranch;
 
++ (COPath *) brokenPath;
 
 /** @taskunit Reference Properties */
 
@@ -59,6 +60,10 @@
  * branch of persistentRoot is.
  */
 @property (nonatomic, readonly, strong) ETUUID *branch;
+/**
+ * Returns whether this is a [COPath brokenPath]
+ */
+@property (nonatomic, readonly, assign) BOOL isBroken;
 
 
 /** @taskunit Persistent String Representation */

--- a/StorageDataModel/COPath.m
+++ b/StorageDataModel/COPath.m
@@ -42,7 +42,7 @@
 
 + (COPath *) brokenPath
 {
-    return [COBrokenPath new];
+	return [COBrokenPath new];
 }
 
 + (COPath *) pathWithString: (NSString*) pathString
@@ -76,7 +76,7 @@
 
 - (BOOL) isBroken
 {
-    return NO;
+	return NO;
 }
 
 - (NSString *) stringValue
@@ -127,32 +127,32 @@
 
 - (BOOL) isBroken
 {
-    return YES;
+	return YES;
 }
 
 - (id) copyWithZone: (NSZone *)zone
 {
-    return self;
+	return self;
 }
 
 - (NSString *) stringValue
 {
-    return @"COBrokenPath";
+	return @"COBrokenPath";
 }
 
 - (NSUInteger) hash
 {
-    return (NSUInteger)self;
+	return (NSUInteger)self;
 }
 
 - (BOOL) isEqual: (id)anObject
 {
-    return NO;
+	return NO;
 }
 
 - (NSString *) description
 {
-    return [self stringValue];
+	return [self stringValue];
 }
 
 @end

--- a/StorageDataModel/COPath.m
+++ b/StorageDataModel/COPath.m
@@ -9,6 +9,11 @@
 #import <EtoileFoundation/Macros.h>
 #import <EtoileFoundation/ETUUID.h>
 
+
+@interface COBrokenPath : COPath
+@end
+
+
 @implementation COPath
 
 @synthesize persistentRoot = _persistentRoot;
@@ -33,6 +38,11 @@
 							 branch: (ETUUID*)aBranch
 {
 	return [[self alloc] initWithPersistentRoot: aRoot branch: aBranch];
+}
+
++ (COPath *) brokenPath
+{
+    return [COBrokenPath new];
 }
 
 + (COPath *) pathWithString: (NSString*) pathString
@@ -62,6 +72,11 @@
 - (id) copyWithZone: (NSZone *)zone
 {
 	return self;
+}
+
+- (BOOL) isBroken
+{
+    return NO;
 }
 
 - (NSString *) stringValue
@@ -103,6 +118,41 @@
 - (NSString *) description
 {
 	return [self stringValue];
+}
+
+@end
+
+
+@implementation COBrokenPath
+
+- (BOOL) isBroken
+{
+    return YES;
+}
+
+- (id) copyWithZone: (NSZone *)zone
+{
+    return self;
+}
+
+- (NSString *) stringValue
+{
+    return @"COBrokenPath";
+}
+
+- (NSUInteger) hash
+{
+    return (NSUInteger)self;
+}
+
+- (BOOL) isEqual: (id)anObject
+{
+    return NO;
+}
+
+- (NSString *) description
+{
+    return [self stringValue];
 }
 
 @end

--- a/Tests/Core/TestObjectGraphContext.m
+++ b/Tests/Core/TestObjectGraphContext.m
@@ -675,4 +675,94 @@
     UKObjectsEqual([NSNull null], itemContentsArray[0]);
 }
 
+- (void) testCrossContextReferencedObjectGraphContextDeallocated
+{
+    @autoreleasepool {
+        COObjectGraphContext *ctx2 = [COObjectGraphContext new];
+        
+        OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
+        ctx2root.label = @"ctx2root";
+        [ctx2 setRootObject: ctx2root];
+
+        // create a link from ctx1 to ctx2
+        [root1 addObject: ctx2root];
+        
+        UKObjectsNotSame(ctx1, ctx2root.objectGraphContext);
+        UKObjectsEqual(ctx2root, root1.contents[0]);
+        
+        NSLog(@"%@", ctx1.items);
+    }
+    
+    // check that ctx1 is still valid?
+    
+    UKTrue([root1.contents isEmpty]);
+    
+    NSLog(@"%@", [ctx1 detailedDescription]);
+}
+
+- (void) test
+{
+    // add a child in ctx1
+    OutlineItem *ctx1obj = [[OutlineItem alloc] initWithObjectGraphContext: ctx1];
+    ctx1obj.label = @"ctx1obj";
+    
+    // create a ctx2
+    
+    COObjectGraphContext *ctx2 = [COObjectGraphContext new];
+    OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
+    ctx2root.label = @"ctx2root";
+    [ctx2 setRootObject: ctx2root];
+    
+    // create a ctx3
+    
+    COObjectGraphContext *ctx3 = [COObjectGraphContext new];
+    OutlineItem *ctx3root = [[OutlineItem alloc] initWithObjectGraphContext: ctx3];
+    ctx3root.label = @"ctx3root";
+    [ctx3 setRootObject: ctx3root];
+    
+    // create a link from ctx1 to ctx2 and 3
+    [ctx1obj addObject: ctx2root];
+    [ctx1obj addObject: ctx3root];
+
+    UKObjectsSame(ctx1obj, [ctx2root parentContainer]);
+    UKObjectsSame(ctx1obj, [ctx3root parentContainer]);
+    
+    [ctx1 removeUnreachableObjects];
+    
+    UKNil([ctx2root parentContainer]);
+    UKNil([ctx3root parentContainer]);
+}
+
+- (void) testCrossContextReferencedObjectDeallocated
+{
+    COObjectGraphContext *ctx2 = [COObjectGraphContext new];
+    
+    OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
+    ctx2root.label = @"ctx2root";
+    [ctx2 setRootObject: ctx2root];
+    
+    OutlineItem *ctx2obj = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
+    ctx2obj.label = @"ctx2obj";
+
+    // create a link from ctx1 to ctx2
+    [root1 addObject: ctx2obj];
+    
+    NSArray *ctx1ig = [ctx1 items];
+    UKFalse([root1.contents isEmpty]);
+    
+    // GC ctx2obj (it's not set as the root object)
+    UKFalse([ctx2obj isZombie]);
+    [ctx2 removeUnreachableObjects];
+    UKTrue([ctx2obj isZombie]);
+    
+    // check that ctx1 is still valid?
+    UKTrue([root1.contents isEmpty]);
+    
+    // It should serialize to COBrokenPath
+    COItem *item = [root1 storeItem];
+    NSArray *itemContentsArray = [item valueForAttribute: @"contents"];
+    UKIntsEqual(1, itemContentsArray.count);
+    UKTrue([itemContentsArray[0] isBroken]);
+}
+
 @end

--- a/Tests/Core/TestObjectGraphContext.m
+++ b/Tests/Core/TestObjectGraphContext.m
@@ -600,6 +600,21 @@
 		withUserInfo: @{ CORelinquishedObjectsKey : @[garbage] }];
 }
 
+- (void) testRelinquishOnDealloc
+{
+    [self checkBlock: ^{
+        @autoreleasepool {
+            COObjectGraphContext *testCtx = [COObjectGraphContext new];
+            OutlineItem *child1 = [[OutlineItem alloc] initWithObjectGraphContext: testCtx];
+            child1.label = @"child1";
+            [testCtx setRootObject: child1];
+        }
+    } postsNotification: COObjectGraphContextWillRelinquishObjectsNotification
+              withCount: 1
+             fromObject: nil
+           withUserInfo: nil];
+}
+
 #pragma mark - COObjectGraphContextWillRelinquishObjectsNotification
 
 - (void) testBeginEndBatchNotification

--- a/Tests/Core/TestObjectGraphContext.m
+++ b/Tests/Core/TestObjectGraphContext.m
@@ -711,14 +711,14 @@
     COObjectGraphContext *ctx2 = [COObjectGraphContext new];
     OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
     ctx2root.label = @"ctx2root";
-    [ctx2 setRootObject: ctx2root];
+    ctx2.rootObject = ctx2root;
     
     // create a ctx3
     
     COObjectGraphContext *ctx3 = [COObjectGraphContext new];
     OutlineItem *ctx3root = [[OutlineItem alloc] initWithObjectGraphContext: ctx3];
     ctx3root.label = @"ctx3root";
-    [ctx3 setRootObject: ctx3root];
+    ctx3.rootObject = ctx3root;
     
     // create a link from ctx1 to ctx2 and 3
     [ctx1obj addObject: ctx2root];
@@ -739,7 +739,7 @@
     
     OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
     ctx2root.label = @"ctx2root";
-    [ctx2 setRootObject: ctx2root];
+    ctx2.rootObject = ctx2root;
     
     OutlineItem *ctx2obj = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
     ctx2obj.label = @"ctx2obj";

--- a/Tests/Core/TestObjectGraphContext.m
+++ b/Tests/Core/TestObjectGraphContext.m
@@ -602,17 +602,17 @@
 
 - (void) testRelinquishOnDealloc
 {
-    [self checkBlock: ^{
-        @autoreleasepool {
-            COObjectGraphContext *testCtx = [COObjectGraphContext new];
-            OutlineItem *child1 = [[OutlineItem alloc] initWithObjectGraphContext: testCtx];
-            child1.label = @"child1";
-            [testCtx setRootObject: child1];
-        }
-    } postsNotification: COObjectGraphContextWillRelinquishObjectsNotification
-              withCount: 1
-             fromObject: nil
-           withUserInfo: nil];
+	[self checkBlock: ^{
+		@autoreleasepool {
+			COObjectGraphContext *testCtx = [COObjectGraphContext new];
+			OutlineItem *child1 = [[OutlineItem alloc] initWithObjectGraphContext: testCtx];
+			child1.label = @"child1";
+			[testCtx setRootObject: child1];
+		}
+	} postsNotification: COObjectGraphContextWillRelinquishObjectsNotification
+			  withCount: 1
+			 fromObject: nil
+		   withUserInfo: nil];
 }
 
 #pragma mark - COObjectGraphContextWillRelinquishObjectsNotification
@@ -677,92 +677,92 @@
 
 - (void) testCrossContextReferencedObjectGraphContextDeallocated
 {
-    @autoreleasepool {
-        COObjectGraphContext *ctx2 = [COObjectGraphContext new];
-        
-        OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
-        ctx2root.label = @"ctx2root";
-        [ctx2 setRootObject: ctx2root];
+	@autoreleasepool {
+		COObjectGraphContext *ctx2 = [COObjectGraphContext new];
+		
+		OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
+		ctx2root.label = @"ctx2root";
+		[ctx2 setRootObject: ctx2root];
 
-        // create a link from ctx1 to ctx2
-        [root1 addObject: ctx2root];
-        
-        UKObjectsNotSame(ctx1, ctx2root.objectGraphContext);
-        UKObjectsEqual(ctx2root, root1.contents[0]);
-        
-        NSLog(@"%@", ctx1.items);
-    }
-    
-    // check that ctx1 is still valid?
-    
-    UKTrue([root1.contents isEmpty]);
-    
-    NSLog(@"%@", [ctx1 detailedDescription]);
+		// create a link from ctx1 to ctx2
+		[root1 addObject: ctx2root];
+		
+		UKObjectsNotSame(ctx1, ctx2root.objectGraphContext);
+		UKObjectsEqual(ctx2root, root1.contents[0]);
+		
+		NSLog(@"%@", ctx1.items);
+	}
+	
+	// check that ctx1 is still valid?
+	
+	UKTrue([root1.contents isEmpty]);
+	
+	NSLog(@"%@", [ctx1 detailedDescription]);
 }
 
 - (void) testCrossContextReferencedObjectDeallocatedWithTwoReferences
 {
-    // add a child in ctx1
-    OutlineItem *ctx1obj = [[OutlineItem alloc] initWithObjectGraphContext: ctx1];
-    ctx1obj.label = @"ctx1obj";
-    
-    // create a ctx2
-    
-    COObjectGraphContext *ctx2 = [COObjectGraphContext new];
-    OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
-    ctx2root.label = @"ctx2root";
-    ctx2.rootObject = ctx2root;
-    
-    // create a ctx3
-    
-    COObjectGraphContext *ctx3 = [COObjectGraphContext new];
-    OutlineItem *ctx3root = [[OutlineItem alloc] initWithObjectGraphContext: ctx3];
-    ctx3root.label = @"ctx3root";
-    ctx3.rootObject = ctx3root;
-    
-    // create a link from ctx1 to ctx2 and 3
-    [ctx1obj addObject: ctx2root];
-    [ctx1obj addObject: ctx3root];
+	// add a child in ctx1
+	OutlineItem *ctx1obj = [[OutlineItem alloc] initWithObjectGraphContext: ctx1];
+	ctx1obj.label = @"ctx1obj";
+	
+	// create a ctx2
+	
+	COObjectGraphContext *ctx2 = [COObjectGraphContext new];
+	OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
+	ctx2root.label = @"ctx2root";
+	ctx2.rootObject = ctx2root;
+	
+	// create a ctx3
+	
+	COObjectGraphContext *ctx3 = [COObjectGraphContext new];
+	OutlineItem *ctx3root = [[OutlineItem alloc] initWithObjectGraphContext: ctx3];
+	ctx3root.label = @"ctx3root";
+	ctx3.rootObject = ctx3root;
+	
+	// create a link from ctx1 to ctx2 and 3
+	[ctx1obj addObject: ctx2root];
+	[ctx1obj addObject: ctx3root];
 
-    UKObjectsSame(ctx1obj, [ctx2root parentContainer]);
-    UKObjectsSame(ctx1obj, [ctx3root parentContainer]);
-    
-    [ctx1 removeUnreachableObjects];
-    
-    UKNil([ctx2root parentContainer]);
-    UKNil([ctx3root parentContainer]);
+	UKObjectsSame(ctx1obj, [ctx2root parentContainer]);
+	UKObjectsSame(ctx1obj, [ctx3root parentContainer]);
+	
+	[ctx1 removeUnreachableObjects];
+	
+	UKNil([ctx2root parentContainer]);
+	UKNil([ctx3root parentContainer]);
 }
 
 - (void) testCrossContextReferencedObjectDeallocated
 {
-    COObjectGraphContext *ctx2 = [COObjectGraphContext new];
-    
-    OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
-    ctx2root.label = @"ctx2root";
-    ctx2.rootObject = ctx2root;
-    
-    OutlineItem *ctx2obj = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
-    ctx2obj.label = @"ctx2obj";
+	COObjectGraphContext *ctx2 = [COObjectGraphContext new];
+	
+	OutlineItem *ctx2root = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
+	ctx2root.label = @"ctx2root";
+	ctx2.rootObject = ctx2root;
+	
+	OutlineItem *ctx2obj = [[OutlineItem alloc] initWithObjectGraphContext: ctx2];
+	ctx2obj.label = @"ctx2obj";
 
-    // create a link from ctx1 to ctx2
-    [root1 addObject: ctx2obj];
-    
-    NSArray *ctx1ig = [ctx1 items];
-    UKFalse([root1.contents isEmpty]);
-    
-    // GC ctx2obj (it's not set as the root object)
-    UKFalse([ctx2obj isZombie]);
-    [ctx2 removeUnreachableObjects];
-    UKTrue([ctx2obj isZombie]);
-    
-    // check that ctx1 is still valid?
-    UKTrue([root1.contents isEmpty]);
-    
-    // It should serialize to COBrokenPath
-    COItem *item = [root1 storeItem];
-    NSArray *itemContentsArray = [item valueForAttribute: @"contents"];
-    UKIntsEqual(1, itemContentsArray.count);
-    UKTrue([itemContentsArray[0] isBroken]);
+	// create a link from ctx1 to ctx2
+	[root1 addObject: ctx2obj];
+	
+	NSArray *ctx1ig = [ctx1 items];
+	UKFalse([root1.contents isEmpty]);
+	
+	// GC ctx2obj (it's not set as the root object)
+	UKFalse([ctx2obj isZombie]);
+	[ctx2 removeUnreachableObjects];
+	UKTrue([ctx2obj isZombie]);
+	
+	// check that ctx1 is still valid?
+	UKTrue([root1.contents isEmpty]);
+	
+	// It should serialize to COBrokenPath
+	COItem *item = [root1 storeItem];
+	NSArray *itemContentsArray = [item valueForAttribute: @"contents"];
+	UKIntsEqual(1, itemContentsArray.count);
+	UKTrue([itemContentsArray[0] isBroken]);
 }
 
 @end

--- a/Tests/Core/TestObjectGraphContext.m
+++ b/Tests/Core/TestObjectGraphContext.m
@@ -700,7 +700,7 @@
     NSLog(@"%@", [ctx1 detailedDescription]);
 }
 
-- (void) test
+- (void) testCrossContextReferencedObjectDeallocatedWithTwoReferences
 {
     // add a child in ctx1
     OutlineItem *ctx1obj = [[OutlineItem alloc] initWithObjectGraphContext: ctx1];

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -805,6 +805,38 @@
 	UKObjectsEqual(A(@"a"), array);
 }
 
+- (void)testMultipleBrokenPaths
+{
+    @autoreleasepool {
+        COPath *br1 = [COPath brokenPath];
+        COPath *br2 = [COPath brokenPath];
+        [array addReference: br1];
+        [array addReference: br2];
+    }
+    // Ensure the array retained both
+    UKTrue([[array referenceAtIndex: 0] isBroken]);
+    UKTrue([[array referenceAtIndex: 1] isBroken]);
+}
+
+- (void)testMultipleBrokenPathsReplacement
+{
+    [array addObject: @"a"];
+    [array addObject: @"b"];
+    [array addObject: @"c"];
+    @autoreleasepool {
+        COPath *br1 = [COPath brokenPath];
+        COPath *br2 = [COPath brokenPath];
+        COPath *br3 = [COPath brokenPath];
+        [array replaceReferenceAtIndex: 0 withReference: br1];
+        [array replaceReferenceAtIndex: 1 withReference: br2];
+        [array replaceReferenceAtIndex: 2 withReference: br3];
+    }
+    // Ensure the array retained all
+    UKTrue([[array referenceAtIndex: 0] isBroken]);
+    UKTrue([[array referenceAtIndex: 1] isBroken]);
+    UKTrue([[array referenceAtIndex: 2] isBroken]);
+}
+
 @end
 
 #pragma mark - TestUnsafeRetainedMutableSet
@@ -880,6 +912,34 @@
 	UKObjectsEqual(S(), set);
 	[set addObject: @"a"];
 	UKObjectsEqual(S(@"a"), set);
+}
+
+- (void)testMultipleBrokenPaths
+{
+    UKIntsEqual(0, set.count);
+    [set addObject: @"a"];
+    [set addObject: @"b"];
+    UKIntsEqual(2, set.count);
+    
+    @autoreleasepool {
+        [set removeReference: @"b"];
+        [set addReference: [COPath brokenPath]];
+        UKIntsEqual(1, set.count);
+    }
+    
+    @autoreleasepool {
+        [set removeReference: @"a"];
+        [set addReference: [COPath brokenPath]];
+        UKIntsEqual(0, set.count);
+    }
+    
+    UKIntsEqual(0, set.allObjects.count);
+    UKIntsEqual(2, set.allReferences.count);
+    
+    for (COPath *path in set.allReferences)
+    {
+        UKTrue(path.isBroken);
+    }
 }
 
 @end

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -807,34 +807,34 @@
 
 - (void)testMultipleBrokenPaths
 {
-    @autoreleasepool {
-        COPath *br1 = [COPath brokenPath];
-        COPath *br2 = [COPath brokenPath];
-        [array addReference: br1];
-        [array addReference: br2];
-    }
-    // Ensure the array retained both
-    UKTrue([[array referenceAtIndex: 0] isBroken]);
-    UKTrue([[array referenceAtIndex: 1] isBroken]);
+	@autoreleasepool {
+		COPath *br1 = [COPath brokenPath];
+		COPath *br2 = [COPath brokenPath];
+		[array addReference: br1];
+		[array addReference: br2];
+	}
+	// Ensure the array retained both
+	UKTrue([[array referenceAtIndex: 0] isBroken]);
+	UKTrue([[array referenceAtIndex: 1] isBroken]);
 }
 
 - (void)testMultipleBrokenPathsReplacement
 {
-    [array addObject: @"a"];
-    [array addObject: @"b"];
-    [array addObject: @"c"];
-    @autoreleasepool {
-        COPath *br1 = [COPath brokenPath];
-        COPath *br2 = [COPath brokenPath];
-        COPath *br3 = [COPath brokenPath];
-        [array replaceReferenceAtIndex: 0 withReference: br1];
-        [array replaceReferenceAtIndex: 1 withReference: br2];
-        [array replaceReferenceAtIndex: 2 withReference: br3];
-    }
-    // Ensure the array retained all
-    UKTrue([[array referenceAtIndex: 0] isBroken]);
-    UKTrue([[array referenceAtIndex: 1] isBroken]);
-    UKTrue([[array referenceAtIndex: 2] isBroken]);
+	[array addObject: @"a"];
+	[array addObject: @"b"];
+	[array addObject: @"c"];
+	@autoreleasepool {
+		COPath *br1 = [COPath brokenPath];
+		COPath *br2 = [COPath brokenPath];
+		COPath *br3 = [COPath brokenPath];
+		[array replaceReferenceAtIndex: 0 withReference: br1];
+		[array replaceReferenceAtIndex: 1 withReference: br2];
+		[array replaceReferenceAtIndex: 2 withReference: br3];
+	}
+	// Ensure the array retained all
+	UKTrue([[array referenceAtIndex: 0] isBroken]);
+	UKTrue([[array referenceAtIndex: 1] isBroken]);
+	UKTrue([[array referenceAtIndex: 2] isBroken]);
 }
 
 @end
@@ -916,30 +916,30 @@
 
 - (void)testMultipleBrokenPaths
 {
-    UKIntsEqual(0, set.count);
-    [set addObject: @"a"];
-    [set addObject: @"b"];
-    UKIntsEqual(2, set.count);
-    
-    @autoreleasepool {
-        [set removeReference: @"b"];
-        [set addReference: [COPath brokenPath]];
-        UKIntsEqual(1, set.count);
-    }
-    
-    @autoreleasepool {
-        [set removeReference: @"a"];
-        [set addReference: [COPath brokenPath]];
-        UKIntsEqual(0, set.count);
-    }
-    
-    UKIntsEqual(0, set.allObjects.count);
-    UKIntsEqual(2, set.allReferences.count);
-    
-    for (COPath *path in set.allReferences)
-    {
-        UKTrue(path.isBroken);
-    }
+	UKIntsEqual(0, set.count);
+	[set addObject: @"a"];
+	[set addObject: @"b"];
+	UKIntsEqual(2, set.count);
+	
+	@autoreleasepool {
+		[set removeReference: @"b"];
+		[set addReference: [COPath brokenPath]];
+		UKIntsEqual(1, set.count);
+	}
+	
+	@autoreleasepool {
+		[set removeReference: @"a"];
+		[set addReference: [COPath brokenPath]];
+		UKIntsEqual(0, set.count);
+	}
+	
+	UKIntsEqual(0, set.allObjects.count);
+	UKIntsEqual(2, set.allReferences.count);
+	
+	for (COPath *path in set.allReferences)
+	{
+		UKTrue(path.isBroken);
+	}
 }
 
 @end

--- a/Tests/Model/TestCollection.m
+++ b/Tests/Model/TestCollection.m
@@ -188,6 +188,18 @@
 	UKObjectsEqual(S(tag), [copy tags]);
 }
 
+- (void)testSimpleCrossReference
+{
+    COTag *tag = [[ctx insertNewPersistentRootWithEntityName: @"COTag"] rootObject];
+    COObject *original = [[ctx insertNewPersistentRootWithEntityName: @"COObject"] rootObject];
+    
+    [ctx commit];
+    
+    [tag addObject: original];
+    
+    UKObjectsEqual(A(original), [tag content]);
+    UKObjectsEqual(S(tag), [original tags]);
+}
 - (void)testSmartGroup
 {
 	COPersistentRoot *persistentRoot = [ctx insertNewPersistentRootWithEntityName: @"COSmartGroup"];

--- a/Tests/Model/TestCollection.m
+++ b/Tests/Model/TestCollection.m
@@ -190,15 +190,15 @@
 
 - (void)testSimpleCrossReference
 {
-    COTag *tag = [[ctx insertNewPersistentRootWithEntityName: @"COTag"] rootObject];
-    COObject *original = [[ctx insertNewPersistentRootWithEntityName: @"COObject"] rootObject];
-    
-    [ctx commit];
-    
-    [tag addObject: original];
-    
-    UKObjectsEqual(A(original), [tag content]);
-    UKObjectsEqual(S(tag), [original tags]);
+	COTag *tag = [[ctx insertNewPersistentRootWithEntityName: @"COTag"] rootObject];
+	COObject *original = [[ctx insertNewPersistentRootWithEntityName: @"COObject"] rootObject];
+	
+	[ctx commit];
+	
+	[tag addObject: original];
+	
+	UKObjectsEqual(A(original), [tag content]);
+	UKObjectsEqual(S(tag), [original tags]);
 }
 - (void)testSmartGroup
 {


### PR DESCRIPTION
Replace any dangling references in other object graph contexts to the one being deallocated with [COPath brokenPath] placeholder objects.
