### PR TITLE
History compaction placeholder node

### DIFF
--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -849,6 +849,13 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
     
     COPersistentRootInfo *info =
 		[[self store] persistentRootInfoForUUID: [self UUID]];
+	
+	/* If we are receiving a changed/compacted notification but the persistent
+	   root has been finalized in the meantime (distributed notifications are 
+	   delivered in LIFO order). */
+	if (info == nil)
+		return;
+
     _savedState = info;
     
     for (ETUUID *uuid in [info branchUUIDs])

--- a/Store/COHistoryCompaction.h
+++ b/Store/COHistoryCompaction.h
@@ -68,6 +68,9 @@
  *
  * Branches not previously marked as deleted are ignored.
  *
+ * To finalize a parent branch, the child branches must all appear in the
+ * returned set and have been previously marked as deleted.
+ *
  * To attempt finalizing all branches, return -compactableBranchUUIDs.
  */
 @property (nonatomic, readonly) NSSet *finalizableBranchUUIDs;
@@ -87,7 +90,19 @@
 /** @taskunit Revision Status */
 
 
-- (NSSet *)deadRevisionUUIDsForPersistentRootUUIDs: (NSArray *)persistentRootUUIDs;
+/**
+ * Returns the live revision sets per persistent root.
+ *
+ * When compacting the store, all revisions older than the oldest revision in 
+ * this set will be discarded, and all revisions newer will be kept.
+ *
+ * Any branch with revisions appearing in this set will be kept.
+ *
+ * For a branch forked from another branch, the revision corresponding to the 
+ * branch creation is always treated as a live one until the forked branch is 
+ * deleted (not yet implemented). No matter which revisions you return, this 
+ * ensures you cannot accidentally create detached branches.
+ */
 - (NSSet *)liveRevisionUUIDsForPersistentRootUUIDs: (NSArray *)persistentRootUUIDs;
 
 

--- a/Tests/Undo/TestUndoTrackHistoryCompaction.m
+++ b/Tests/Undo/TestUndoTrackHistoryCompaction.m
@@ -202,13 +202,11 @@
 	compaction.deadRevisionUUIDs = @{ persistentRoot.UUID : SA((id)[[deadRevs mappedCollection] UUID]) };
 
 	NSArray *liveCommands = [track.allCommands subarrayFromIndex: 3];
-	/* COCommandSetCurrentVersionForBranch.oldRevisionID is kept alive by 
-	   COUndoTrackHistoryCompaction logic, this means the oldest kept revision 
-	   will be the revision prior to track.allCommands[3].newRevisionID.
+	/* The oldest kept revision is track.allCommands[3].oldRevision, so
+	   track.allCommands[2] is discarded but track.allCommands[2].revision isn't.
 
-	   This explains the index mistmatch between [oldRevs subarrayFromIndex: 2]
-	   and the next line. */
-	NSDictionary *newRevs = [self compactUpToCommand: track.allCommands[3]
+	   We discard 3 commands and 2 revisions. */
+	NSDictionary *newRevs = [self compactUpToCommand: track.allCommands[2]
 	                             expectingCompaction: compaction];
 
 	UKObjectsEqual(liveRevs, newRevs[persistentRoot.UUID]);
@@ -240,7 +238,7 @@
 
 	NSArray *liveCommands = [track.allCommands subarrayFromIndex: 2];
 	/* See comment in -testCompactPersistentRootWithTrivialHistory */
-	NSDictionary *newRevs = [self compactUpToCommand: track.allCommands[2]
+	NSDictionary *newRevs = [self compactUpToCommand: track.allCommands[1]
 	                             expectingCompaction: compaction];
 	
 	/* Second compaction */
@@ -256,19 +254,15 @@
 	compaction.liveRevisionUUIDs = @{ persistentRoot.UUID : SA((id)[[liveRevs mappedCollection] UUID]) };
 	compaction.deadRevisionUUIDs = @{ persistentRoot.UUID : SA((id)[[deadRevs mappedCollection] UUID]) };
 
-	/* COCommandSetCurrentVersionForBranch.oldRevisionID is kept alive by 
-	   COUndoTrackHistoryCompaction logic, this means the oldest kept revision 
-	   will be the revision prior to track.allCommands[2].newRevisionID.
-
-	   However oldRevs starts with the old revision ID for track.allCommands[0]
-	   and the old revision ID for track.allCommands[1] (which happens to be the
-	   revision ID bound to track.allCommands[0]). Both will be discarded.
+	/* The oldest kept revision is track.allCommands[2].oldRevision, so
+	   track.allCommands[1] is discarded but track.allCommands[1].revision isn't.
 	   
-	   After a first compaction, we always have an old revision to discard 
-	   together with the first command, so there is no index mismatch between 
-	   [oldRevs subarrayFromIndex: 2] and the next line. */
+	   The latest discarded revision is track.allCommands[0].oldRevision, that
+	   isn't nil since this is the second compaction.
+
+	   We discard 2 commands and 2 revisions. */
 	liveCommands = [track.allCommands subarrayFromIndex: 2];
-	newRevs = [self compactUpToCommand: track.allCommands[2]
+	newRevs = [self compactUpToCommand: track.allCommands[1]
 	               expectingCompaction: compaction];
 
 	UKObjectsEqual(liveRevs, newRevs[persistentRoot.UUID]);
@@ -298,7 +292,7 @@
 
 	NSArray *liveCommands = [track.allCommands subarrayFromIndex: 6];
 	/* See comment in -testCompactPersistentRootWithTrivialHistory */
-	NSDictionary *newRevs = [self compactUpToCommand: track.allCommands[6]
+	NSDictionary *newRevs = [self compactUpToCommand: track.allCommands[5]
 	                             expectingCompaction: compaction];
 
 	UKObjectsEqual(mainLiveRevs, newRevs[persistentRoot.UUID]);
@@ -519,7 +513,7 @@
 	   command on the other concrete track. The old revision corresponding to 
 	   'Bop' is not kept, and we only delete the two first revisions.
 	   See also -testCompactPersistentRootWithTrivialHistory. */
-	NSDictionary *newRevs = [self compactUpToCommand: track.allCommands[3]
+	NSDictionary *newRevs = [self compactUpToCommand: track.allCommands[2]
 	                             expectingCompaction: compaction];
 
 	UKObjectsEqual(liveRevs, newRevs[persistentRoot.UUID]);

--- a/Undo/COCommandGroup.h
+++ b/Undo/COCommandGroup.h
@@ -89,14 +89,14 @@
  * this point, the last undo and the previously created commands that follow it, 
  * don't appear in the Undo track unless divergent commands are explicitly shown.
  *
- * Before compaction, the first command in a track is always a non-persistent
+ * The first command in a track is always a non-persistent
  * COEndOfUndoTrackPlaceholderNode instance; its parent UUID is nil. The first 
  * persistent divergent commands in a track have a parent UUID equal to
  * [[COEndOfUndoTrackPlaceholderNode sharedInstance] UUID].
  *
- * After compaction, the first command in a track is never a
- * COEndOfUndoTrackPlaceholderNode instance; its parent UUID  corresponds to a 
- * deleted command.
+ * Before compaction, the parent UUID of the first recorded command is the 
+ * placeholder node UUID. After compaction, the parent UUID of the oldest kept 
+ * command corresponds to a deleted command.
  *
  * See also -[COUndoTrack childrenOfNode:].
  */

--- a/Undo/COUndoTrack.m
+++ b/Undo/COUndoTrack.m
@@ -491,10 +491,7 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 		[ancestorUUIDsOfA addObject: temp.UUID];
 	}
 
-	if ([[self nodes].firstObject isEqual: [COEndOfUndoTrackPlaceholderNode sharedInstance]])
-	{
-		ETAssert([ancestorUUIDsOfA containsObject: [[COEndOfUndoTrackPlaceholderNode sharedInstance] UUID]]);
-	}
+	ETAssert([ancestorUUIDsOfA containsObject: [[COEndOfUndoTrackPlaceholderNode sharedInstance] UUID]]);
 
 	for (id<COTrackNode> temp = commitB; temp != nil; temp = [temp parentNode])
 	{
@@ -671,7 +668,6 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	{
 		NSMutableArray *undoNodes = [NSMutableArray new];
 		NSMutableArray *redoNodes = [NSMutableArray new];
-		BOOL isCompacted = NO;
 		
 		for (COUndoTrackState *trackState in [_trackStateForName allValues])
 		{
@@ -688,7 +684,6 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	
 				if (isDeletedCommand)
 				{
-					isCompacted = YES;
 					break;
 				}
 
@@ -712,11 +707,8 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 		
 		[redoNodes sortUsingDescriptors:
 		 @[[NSSortDescriptor sortDescriptorWithKey: @"sequenceNumber" ascending: YES]]];
-		
-		if (!isCompacted)
-		{
-			[_nodesOnCurrentUndoBranch addObject: [COEndOfUndoTrackPlaceholderNode sharedInstance]];
-		}
+
+		[_nodesOnCurrentUndoBranch addObject: [COEndOfUndoTrackPlaceholderNode sharedInstance]];
 		[_nodesOnCurrentUndoBranch addObjectsFromArray: undoNodes];
 		[_nodesOnCurrentUndoBranch addObjectsFromArray: redoNodes];
 	}
@@ -827,7 +819,10 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	NSDictionary *userInfo = [notif userInfo];
 	COUndoTrackState *notifState = [COUndoTrackState new];
 	notifState.trackName = userInfo[COUndoTrackStoreTrackName];
-	notifState.headCommandUUID = [ETUUID UUIDWithString: userInfo[COUndoTrackStoreTrackHeadCommandUUID]];
+	if (userInfo[COUndoTrackStoreTrackHeadCommandUUID] != nil)
+	{
+		notifState.headCommandUUID = [ETUUID UUIDWithString: userInfo[COUndoTrackStoreTrackHeadCommandUUID]];
+	}
 	if (userInfo[COUndoTrackStoreTrackCurrentCommandUUID] != nil)
 	{
 		notifState.currentCommandUUID = [ETUUID UUIDWithString: userInfo[COUndoTrackStoreTrackCurrentCommandUUID]];

--- a/Undo/COUndoTrackHistoryCompaction.h
+++ b/Undo/COUndoTrackHistoryCompaction.h
@@ -43,7 +43,6 @@
 	@private
 	COUndoTrack *_undoTrack;
 	COCommandGroup *_oldestCommandToKeep;
-	NSMutableSet *_additionalCommandsToKeep;
 	NSMutableSet *_finalizablePersistentRootUUIDs;
 	NSMutableSet *_compactablePersistentRootUUIDs;
 	NSMutableSet *_finalizableBranchUUIDs;
@@ -52,6 +51,21 @@
 	NSMutableDictionary *_liveRevisionUUIDs;
 }
 
+/**
+ * <init />
+ * Initializes a compaction strategy to discard any history older than the given
+ * command.
+ *
+ * After compaction, this command becomes the undo track tail. If you undo it, 
+ * you can access the oldest kept state (represented by the track placeholder 
+ * node).
+ *
+ * If you pass the track head or current, all the commands between tail and 
+ * current are discarded (including divergent commands not returned by 
+ * -[COUndoTrack nodes]).
+ *
+ * For nil track or command, raises a NSInvalidArgumentException.
+ */
 - (instancetype)initWithUndoTrack: (COUndoTrack *)aTrack upToCommand: (COCommandGroup *)aCommand;
 
 @property (nonatomic, readonly) COUndoTrack *undoTrack;

--- a/Undo/COUndoTrackHistoryCompaction.h
+++ b/Undo/COUndoTrackHistoryCompaction.h
@@ -41,11 +41,8 @@
  * @section Pattern Undo Track
  *
  * You can pass a pattern undo track to the initalizer, then the compaction 
- * can discard any commands on child tracks, prior to the pattern track current
- * node. 
- *
- * A child track current node can be discarded, when it's not the current node 
- * on the pattern track.
+ * can discard any commands on child tracks, up to the pattern track current
+ * node.
  */
 @interface COUndoTrackHistoryCompaction : NSObject <COHistoryCompaction>
 {
@@ -58,6 +55,7 @@
 	NSMutableSet *_compactableBranchUUIDs;
 	NSMutableDictionary *_deadRevisionUUIDs;
 	NSMutableDictionary *_liveRevisionUUIDs;
+	NSMutableDictionary *_newestDeadRevisionUUIDs;
 }
 
 /**
@@ -73,8 +71,8 @@
  *
  * <list>
  * <item>all commands between tail and current commands are discarded, 
- * including divergent commands not returned by -[COUndoTrack nodes]</item>
- * <item>the current command and all commands more recent than it are kept</item>
+ * including the current command and divergent commands not returned by -[COUndoTrack nodes]</item>
+ * <item>all commands more recent than the current command are kept</item>
  * </list>
  *
  * For nil track or command, or a command that doesn't on the track, raises an
@@ -101,8 +99,10 @@
  * The deletable revision sets when compacting the history, organized by 
  * persistent root UUID.
  *
- * These revisions won't be deleted, when they are inside a live revision range. 
- * See -liveRevisionUUIDs.
+ * These revisions won't be deleted, when they are inside a live revision range.
+ *
+ * This method is a debugging utility, it is never used when compacting the 
+ * store unlike -liveRevisionUUIDs.
  */
 @property (nonatomic, readonly) NSDictionary *deadRevisionUUIDs;
 /**
@@ -113,5 +113,12 @@
  * -deadRevisionUUIDs.
  */
 @property (nonatomic, readonly) NSDictionary *liveRevisionUUIDs;
+/**
+ * Returns the dead revisions per persistent root. 
+ *
+ * This method is similar to -liveRevisionUUIDsForPersistentRootUUIDs:, but is
+ * only available for debugging purpose.
+ */
+- (NSSet *)deadRevisionUUIDsForPersistentRootUUIDs: (NSArray *)persistentRootUUIDs;
 
 @end

--- a/Undo/COUndoTrackStore.m
+++ b/Undo/COUndoTrackStore.m
@@ -319,22 +319,29 @@ NSString * const COUndoTrackStoreTrackCompacted = @"COUndoTrackStoreTrackCompact
     return result;
 }
 
+/**
+ * If all commands have been marked as deleted on the track, returns a track 
+ * state where head and current commands are both nil.
+ */
 - (COUndoTrackState *)stateForTrackNameInCurrentQueue: (NSString *)aName
 {
     assert(dispatch_get_current_queue() == _queue);
 
 	COUndoTrackState *result = nil;
 	FMResultSet *rs = [_db executeQuery:
-		@"SELECT track.trackname, head.uuid AS headuuid, current.uuid AS currentuuid "
+		@"SELECT track.trackname, head.uuid AS headuuid, current.uuid AS currentuuid, head.deleted AS headdeleted "
 		 "FROM tracks AS track "
 		 "LEFT OUTER JOIN commands AS head ON track.headid = head.id "
 		 "LEFT OUTER JOIN commands AS current ON track.currentid = current.id "
-		 "WHERE track.trackname = ?", aName];
+		 "WHERE track.trackname = ? AND headdeleted = 0", aName];
+
+	result = [COUndoTrackState new];
+	result.trackName = aName;
 
 	if ([rs next])
 	{
-		result = [COUndoTrackState new];
-		result.trackName = [rs stringForColumn: @"trackname"];
+		ETAssert([result.trackName isEqual: [rs stringForColumn: @"trackname"]]);
+
 		result.headCommandUUID = [ETUUID UUIDWithData: [rs dataForColumn: @"headuuid"]];
 		if ([rs dataForColumn: @"currentuuid"] != nil)
 		{
@@ -569,7 +576,34 @@ NSString * const COUndoTrackStoreTrackCompacted = @"COUndoTrackStoreTrackCompact
 	@try
 	{
 		dispatch_sync(_queue, ^() {
-			[_db executeUpdate: @"DELETE FROM commands WHERE deleted = 1"];
+			NSArray *compactedTrackNames =
+				[_db arrayForQuery: @"SELECT DISTINCT trackname FROM commands WHERE deleted = 1 "];
+			
+			for (NSString *trackName in compactedTrackNames)
+			{
+				if (_modifiedTrackStateForTrackName[trackName] == nil)
+				{
+					_modifiedTrackStateForTrackName[trackName] = [self stateForTrackNameInCurrentQueue: trackName];
+				}
+				
+				/* When we compact up to the head, we delete all commands
+				   between head and tail including divergent ones, this means
+				   the track becomes empty. */
+				BOOL isEmptyTrack = ([_modifiedTrackStateForTrackName[trackName] headCommandUUID] == nil);
+				
+				if (isEmptyTrack)
+				{
+					[_db executeUpdate: @"DELETE FROM tracks WHERE trackname = ?", trackName];
+					/* If the head was moved back to the past just before the
+					   compaction, then any divergent commands more recent than
+					   the head won't be marked as deleted. */
+					[_db executeUpdate: @"DELETE FROM commands WHERE trackname = ?", trackName];
+				}
+				else
+				{
+					[_db executeUpdate: @"DELETE FROM commands WHERE deleted = 1"];
+				}
+			}
 		});
 	}
 	@finally
@@ -639,7 +673,10 @@ NSString * const COUndoTrackStoreTrackCompacted = @"COUndoTrackStoreTrackCompact
 		NSMutableDictionary *userInfo = [NSMutableDictionary new];
   
 		userInfo[COUndoTrackStoreTrackName] = modifiedTrack;
-		userInfo[COUndoTrackStoreTrackHeadCommandUUID] = [state.headCommandUUID stringValue];
+		if (state.headCommandUUID != nil)
+		{
+			userInfo[COUndoTrackStoreTrackHeadCommandUUID] = [state.headCommandUUID stringValue];
+		}
 		if (state.currentCommandUUID != nil)
 		{
 			userInfo[COUndoTrackStoreTrackCurrentCommandUUID] = [state.currentCommandUUID stringValue];


### PR DESCRIPTION
Here is a quick summary of the changes I did to improve history compaction:

- made possible to compact all commands so the only remaining node is the placeholder node
- fixed compaction to behave in a predictable way with a pattern undo track
  - child track current nodes can now be discarded (thanks to the first change)
- improved public COUndoTrackHistoryCompaction API and simplified implementation
- improved COUndoTrackStore to automatically finalize empty undo tracks rather than keeping them around
- fixed crash when attempting to reload a finalized persistent root (due to an outdated distributed notification)

Concerning this last change (see COPersistentRoot.m diff), I stumbled on it while testing the backup in Placeboard. It was a tricky bug to track down happening 1 time out of 50. When a backup is loaded in Placeboard, the entire model infrastructure operating in background (model factory, synchronization, compaction) of the app is recreated from scratch. This means every COEditingContext, COSQLiteStore and COUndoTrackStore instances are discarded at this time. 

However it seems ARC turns autorelease calls into normal release calls very often (49 time out of 50). So sometimes old COEditingContext will linger around a bit longer and they will catch distributed notifications posted by the new COSQLiteStore. Since old and new stores both have the same UUID (since they share the same store content but at different point in time), the distributed notification is not ignored. If the old store contains a deleted persistent root in memory (but previously finalized on disk) and the new store contains the same persistent root alive, when a compaction is run against the new store, the old store will catch the notification that reports this persistent root as compacted and attempt to reload it with:

	for (ETUUID *persistentRootUUID in compactedPersistentRootUUIDs)
	{
		COPersistentRoot *loaded = [_loadedPersistentRoots objectForKey: persistentRootUUID];

		[loaded storePersistentRootDidChange: notif isDistributed: isDistributed];
		hadChanges = YES;
	}

If loaded corresponds to a finalized to a persistent root in the old store, a crash waiting us ahead. The fix I committed is probably not the most correct one. A better one is probably to uncomment this TODO:

	for (ETUUID *persistentRootUUID in finalizedPersistentRootUUIDs)
	{
		__unused COPersistentRoot *loaded = [_loadedPersistentRoots objectForKey: persistentRootUUID];

		// TODO: [self unloadPersistentRoot: loaded]
		hadChanges = YES;
	}

However I'm not sure we cannot have other issues triggered by such outdated distributed notifications and mismatched store states between memory and disk. What do you think?

I considered adding stuff like a token marking every new store instances at initialization and checking it in the editing context, but this wouldn't work well when we have two different store objects pointing to same store file on disk. (either in the same application or in two different ones).

I guess the best solution is to make the notification handler solid enough to survive any out-of-order delivery of notifications. 

Another solution is to make an explicit -invalidate call that discards the observers when you are done with an editing context.

If you want to play with this issue, comment out the changes in COPersistentRoot.m and an exception should occur right after running -testCompactionsInterleavedWithCommitsAndUndoRedo:

#3	0x000000010037a00b in -[COSQLiteStore itemGraphForRevisionUUID:persistentRoot:] at /Users/qmathe/reps/Etoile/Frameworks/CoreObject/Store/COSQLiteStore.m:559
#4	0x000000010032c381 in -[COPersistentRoot setCurrentBranchObjectGraphToRevisionUUID:persistentRootUUID:] at /Users/qmathe/reps/Etoile/Frameworks/CoreObject/Core/COPersistentRoot.m:211
#5	0x000000010032c4c6 in -[COPersistentRoot reloadCurrentBranchObjectGraph] at /Users/qmathe/reps/Etoile/Frameworks/CoreObject/Core/COPersistentRoot.m:219
#6	0x000000010033335f in -[COPersistentRoot storePersistentRootDidChange:isDistributed:] at /Users/qmathe/reps/Etoile/Frameworks/CoreObject/Core/COPersistentRoot.m:878
#7	0x0000000100319b47 in -[COEditingContext storePersistentRootsDidChange:isDistributed:] at /Users/qmathe/reps/Etoile/Frameworks/CoreObject/Core/COEditingContext.m:914
#8	0x0000000100318e2f in -[COEditingContext distributedStorePersistentRootsDidChange:] at /Users/qmathe/reps/Etoile/Frameworks/CoreObject/Core/COEditingContext.m:793
#9	0x00007fff8b47a45c in __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ ()
#10	0x00007fff8b437f8e in ____CFXNotificationPostToken_block_invoke ()
#11	0x00007fff8b3da8ec in __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ ()
#12	0x00007fff8b3cc9f5 in __CFRunLoopDoBlocks ()
#13	0x00007fff8b3cc536 in __CFRunLoopRun ()
#14	0x00007fff8b3cbbd8 in CFRunLoopRunSpecific ()
#15	0x00007fff8ad78b29 in -[NSRunLoop(NSRunLoop) runMode:beforeDate:] ()
#16	0x00007fff8ad96d9e in -[NSRunLoop(NSRunLoop) runUntilDate:] ()
#17	0x00000001005054b8 in -[UKRunner runTest:onObject:class:] at /Users/qmathe/reps/Etoile/Frameworks/UnitKit/FrameworkSource/UKRunner.m:332
