### PR TITLE
Optimize cross persistent root ref updates

### DIFF
--- a/Benchmark/TestHistoryNavigationPerformance.m
+++ b/Benchmark/TestHistoryNavigationPerformance.m
@@ -80,14 +80,14 @@ static int commitCounter = 0;
 	NSLog(@"Time to go to newest node on undo track: %0.2fs", goToFirstNodeTime);
 	startDate = [NSDate date];
 	
-	// FIXME: UKTrue(goToFirstNodeTime < 0.5);
+	UKTrue(goToFirstNodeTime < 1.0); // FIXME: 0.5
 
 	[track setCurrentNode: track.nodes.lastObject];
 	
 	NSTimeInterval goToLastNodeTime = [[NSDate date] timeIntervalSinceDate: startDate];
 	NSLog(@"Time to go to oldest node on undo track: %0.2fs", goToLastNodeTime);
 	
-	// FIXME: UKTrue(goToLastNodeTime < 0.5);
+	UKTrue(goToLastNodeTime < 1.0); // FIXME: 0.5
 }
 
 @end

--- a/Core/COCrossPersistentRootDeadRelationshipCache.m
+++ b/Core/COCrossPersistentRootDeadRelationshipCache.m
@@ -70,14 +70,15 @@
 
 - (void)removeReferringObject: (COObject *)aReferrer
 {
-	NSMutableSet *paths = [[_referringObjectToPaths objectForKey: aReferrer] copy];
-	
+	NSMutableSet *paths = [_referringObjectToPaths objectForKey: aReferrer];
+
 	if (paths == nil)
 		return;
 
+	[_referringObjectToPaths removeObjectForKey: aReferrer];
 	for (COPath *path in paths)
 	{
-		[self removeReferringObject: aReferrer forPath: path];
+		[_pathToReferringObjects[path] removeObject: aReferrer];
 	}
 }
 

--- a/Core/COCrossPersistentRootDeadRelationshipCache.m
+++ b/Core/COCrossPersistentRootDeadRelationshipCache.m
@@ -70,24 +70,25 @@
 
 - (void)removeReferringObject: (COObject *)aReferrer
 {
-	NSMutableSet *paths = [_referringObjectToPaths objectForKey: aReferrer];
+	NSMutableSet *paths = [[_referringObjectToPaths objectForKey: aReferrer] copy];
 	
 	if (paths == nil)
 		return;
 
-	[_referringObjectToPaths removeObjectForKey: aReferrer];
-	[_pathToReferringObjects removeObjectsForKeys: paths.allObjects];
+	for (COPath *path in paths)
+	{
+		[self removeReferringObject: aReferrer forPath: path];
+	}
 }
 
 - (void)removePath: (COPath *)aPath
 {
-	NSHashTable *referringObjects = _pathToReferringObjects[aPath];
+	NSHashTable *referringObjects = [_pathToReferringObjects[aPath] copy];
 
 	for (COObject *referrer in referringObjects)
 	{
-		[_referringObjectToPaths removeObjectForKey: referrer];
+		[self removeReferringObject: referrer forPath: aPath];
 	}
-	[_pathToReferringObjects removeObjectForKey: aPath];
 }
 
 @end

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -488,9 +488,6 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 	for (COBranch *branch in _branchForUUID.objectEnumerator)
 	{
-		if (branch.isDeleted)
-			continue;
-
 		COObjectGraphContext *branchObjectGraph = [branch objectGraphContextWithoutUnfaulting];
 
 		if (branchObjectGraph != nil)

--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -162,6 +162,8 @@ NSString * const COPersistentRootAttributeUsedSize = @"COPersistentRootAttribute
      "proot BLOB NOT NULL, current_revid BLOB NOT NULL, "
      "head_revid BLOB NOT NULL, metadata BLOB, deleted BOOLEAN DEFAULT 0, parentbranch BLOB)"];
     
+    [db_ executeUpdate: @"CREATE INDEX IF NOT EXISTS branches_by_proot ON branches(proot)"];
+    
 	[db_ executeUpdate: @"CREATE TABLE IF NOT EXISTS persistentroot_backingstores ("
      "uuid BLOB PRIMARY KEY NOT NULL, backingstore BLOB NOT NULL)"];
 	


### PR DESCRIPTION
Update `-updateCrossPersistentRootReferencesToPersistentRoot` to use the relationship caches, so it only updates object graphs that actually have references to the target.

TestHistoryNavigationPerformance times still are not great, but at least more reasonable :-)
```
2016-01-21 02:06:06.269 Test[61866:791989] Store URL: file:///var/folders/sg/57wxmnq50t18qrgggm4h28sc0000gn/T/TestStore.sqlite
2016-01-21 02:06:06.463 Test[61866:791989] === [TestHistoryNavigationPerformance testGoToOldestAndNewestNodesInHistory] ===
2016-01-21 02:06:07.569 Test[61866:791989] In-memory snapshot is stale
2016-01-21 02:06:07.712 Test[61866:791989] Time to commit 500 new persistent roots with undo track: 1.25s
2016-01-21 02:06:14.738 Test[61866:791989] Time to make 100 commits with undo track: 7.03s
2016-01-21 02:06:15.244 Test[61866:791989] Time to go to newest node on undo track: 0.51s
2016-01-21 02:06:15.547 Test[61866:791989] Time to go to oldest node on undo track: 0.30s
2016-01-21 02:06:16.422 Test[61866:791989] Took 10145 ms
2016-01-21 02:06:16.422 Test[61866:791989] Result: 1 classes, 1 methods, 0 tests, 0 failed, 0 exceptions
```