### PR TITLE
COSQLiteStorePersistentRootBackingStore: store all commits in one table

### DIFF
--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -493,8 +493,11 @@ NSString * const COPersistentRootAttributeUsedSize = @"COPersistentRootAttribute
 - (void) deleteBackingStoreWithUUID: (ETUUID *)aUUID
 {
 #if BACKING_STORES_SHARE_SAME_SQLITE_DB == 1
-	[db_ executeUpdate: [NSString stringWithFormat: @"DROP TABLE IF EXISTS `commits-%@`", aUUID]];
-	[db_ executeUpdate: [NSString stringWithFormat: @"DROP TABLE IF EXISTS `metadata-%@`", aUUID]];
+    COSQLiteStorePersistentRootBackingStore *backing = [backingStores_ objectForKey: aUUID];
+    if (backing != nil)
+    {
+        [backing clearBackingStore];
+    }
 #else
 	
 	// FIXME: Test this

--- a/Tests/Store/TestSQLiteBackingStore.m
+++ b/Tests/Store/TestSQLiteBackingStore.m
@@ -136,7 +136,7 @@
 {
 	NSData *passwordBytes = [@"password" dataUsingEncoding: NSUTF8StringEncoding];
 						   
-	for (NSData *blob in [store.database arrayForQuery: [NSString stringWithFormat: @"SELECT contents FROM %@", [backing tableName]]])
+	for (NSData *blob in [store.database arrayForQuery: @"SELECT contents FROM commits WHERE backinguuid = ?", [[backing UUID] dataValue]])
 	{
 		NSRange rangeOfPassword = [blob rangeOfData: passwordBytes options: 0 range: NSMakeRange(0, blob.length)];
 		if (rangeOfPassword.location != NSNotFound)

--- a/Tests/Store/TestSQLiteStore.m
+++ b/Tests/Store/TestSQLiteStore.m
@@ -678,18 +678,15 @@ static ETUUID *childUUID2;
 {
 #if BACKING_STORES_SHARE_SAME_SQLITE_DB == 1
 	[store testingRunBlockInStoreQueue: ^() {
-		BOOL hasCommitsTable = [[store database] tableExists: [NSString stringWithFormat: @"commits-%@", aUUID]];
-		BOOL hasMetadataTable = [[store database] tableExists: [NSString stringWithFormat: @"metadata-%@", aUUID]];
+		BOOL hasCommits = [[store database] intForQuery: @"SELECT 1 FROM commits WHERE backinguuid = ?", [aUUID dataValue]];
 		
 		if (flag)
 		{
-			UKTrue(hasCommitsTable);
-			UKTrue(hasMetadataTable);
+			UKTrue(hasCommits);
 		}
 		else
 		{
-			UKFalse(hasCommitsTable);
-			UKFalse(hasMetadataTable);
+			UKFalse(hasCommits);
 		}
 	}];
 #endif


### PR DESCRIPTION
May be more efficient for sqlite... it avoids having to recompile new queries for the first time every persistent root is used.

The test suites run a lot faster overall because they are creating thousands of new persistent roots in total.