### PR TITLE
COPersistentRoot: remove _lastTransactionID ivar and store this in a dictionary in COEditingContext.

### DIFF
--- a/Core/COEditingContext+Private.h
+++ b/Core/COEditingContext+Private.h
@@ -85,5 +85,13 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
  * This method is only exposed to be used internally by CoreObject.
  */
 - (COBranch *)branchForUUID: (ETUUID *)aBranch;
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
+- (int64_t)lastTransactionIDForPersistentRootUUID: (ETUUID *)aUUID;
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
+- (void)setLastTransactionID: (int64_t)lastTransactionID forPersistentRootUUID: (ETUUID *)aUUID;
 
 @end

--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -169,6 +169,7 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
 	/** Detect illegal recursive calls to commit */
 	BOOL _inCommit;
 	COObjectGraphContext *_internalTransientObjectGraphContext;
+	NSMutableDictionary *_lastTransactionIDForPersistentRootUUID;
 }
 
 

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -68,8 +68,8 @@
     _isRecordingUndo = YES;
 	_revisionCache = [[CORevisionCache alloc] initWithParentEditingContext: self];
 	_internalTransientObjectGraphContext = [[COObjectGraphContext alloc] initWithModelDescriptionRepository: aRepo];
-	CORegisterCoreObjectMetamodel(_modelDescriptionRepository);
 	_lastTransactionIDForPersistentRootUUID = [NSMutableDictionary new];
+	CORegisterCoreObjectMetamodel(_modelDescriptionRepository);
 
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(storePersistentRootsDidChange:)

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -69,6 +69,7 @@
 	_revisionCache = [[CORevisionCache alloc] initWithParentEditingContext: self];
 	_internalTransientObjectGraphContext = [[COObjectGraphContext alloc] initWithModelDescriptionRepository: aRepo];
 	CORegisterCoreObjectMetamodel(_modelDescriptionRepository);
+	_lastTransactionIDForPersistentRootUUID = [NSMutableDictionary new];
 
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(storePersistentRootsDidChange:)
@@ -970,6 +971,17 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
 		return [proot branchForUUID: aBranch];
 	}
 	return nil;
+}
+
+- (int64_t)lastTransactionIDForPersistentRootUUID: (ETUUID *)aUUID
+{
+	NSNumber *num = _lastTransactionIDForPersistentRootUUID[aUUID];
+	return [num longLongValue];
+}
+
+- (void)setLastTransactionID: (int64_t)lastTransactionID forPersistentRootUUID: (ETUUID *)aUUID
+{
+	_lastTransactionIDForPersistentRootUUID[aUUID] = @(lastTransactionID);
 }
 
 @end

--- a/Core/COPersistentRoot.h
+++ b/Core/COPersistentRoot.h
@@ -183,7 +183,6 @@ extern NSString * const COPersistentRootDidChangeNotification;
     ETUUID *_cheapCopyPersistentRootUUID;
 	NSDictionary *_metadata;    
     BOOL _metadataChanged;
-    int64_t _lastTransactionID;
 	COObjectGraphContext *_currentBranchObjectGraph;
 }
 

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -124,7 +124,7 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
         }
         
         _currentBranchUUID =  [_savedState currentBranchUUID];
-		_lastTransactionID = _savedState.transactionID;
+		[_parentContext setLastTransactionID: _savedState.transactionID forPersistentRootUUID: _UUID];
 		_metadata = _savedState.metadata;
 		
 		[self reloadCurrentBranchObjectGraph];
@@ -542,12 +542,12 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 - (int64_t)lastTransactionID
 {
-	return _lastTransactionID;
+	return [_parentContext lastTransactionIDForPersistentRootUUID: _UUID];
 }
 
 - (void)setLastTransactionID: (int64_t) value
 {
-	_lastTransactionID = value;
+	[_parentContext setLastTransactionID: value forPersistentRootUUID: _UUID];
 }
 
 - (BOOL)commitWithIdentifier: (NSString *)aCommitDescriptorId
@@ -876,7 +876,7 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	// TODO: Test that _everything_ is reloaded
 	
     _currentBranchUUID =  [_savedState currentBranchUUID];
-    _lastTransactionID = _savedState.transactionID;
+    self.lastTransactionID = _savedState.transactionID;
     _metadata = _savedState.metadata;
 	
 	[self reloadCurrentBranchObjectGraph];

--- a/Undo/COUndoTrack.m
+++ b/Undo/COUndoTrack.m
@@ -540,12 +540,12 @@ NSString * const kCOUndoTrackName = @"COUndoTrackName";
 	// Set the last transaction IDs so the store will accept our transaction
 	for (ETUUID *uuid in [txn persistentRootUUIDs])
 	{
-		COPersistentRoot *proot = [_editingContext persistentRootForUUID: uuid];
-		[txn setOldTransactionID: proot.lastTransactionID forPersistentRoot: uuid];
+		int64_t lastTransactionID = [_editingContext lastTransactionIDForPersistentRootUUID: uuid];
+		[txn setOldTransactionID: lastTransactionID forPersistentRoot: uuid];
 		
-		// N.B.: We DO NOT MODIFY proot's lastTransactionID property here, because the
-		// in-memory state is out of date with respect to the store, and we need the
-		// notification mechanism to refresh the in-memory state
+		// N.B.: For loaded persistent roots in ctx, the
+		// in-memory state is out of date with respect to the store, and the
+		// notification mechanism will refresh the in-memory state
 	}
 	
 	BOOL ok = [[_editingContext store] commitStoreTransaction: txn];


### PR DESCRIPTION
This is so we can still retrieve the last transaction ID even if the persistent root is deallocated.