### PR TITLE
COPrimitiveCollection: rewrite `mutable` property.

### DIFF
--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -943,7 +943,7 @@ See +[NSObject typePrefix]. */
 
 	if ([self isCoreObjectCollection: collection])
 	{
-		[collection beginTemporaryModification];
+		[collection beginMutation];
 	}
 
 	if ([propDesc isKeyed])
@@ -956,7 +956,7 @@ See +[NSObject typePrefix]. */
 		// identical to the new one.
 		
 		// NOTE: This mess is because -copy on a COPrimitiveCollection preserves
-		// the number of -beginTemporaryModification calls, and we want the copy
+		// the number of -beginMutation calls, and we want the copy
 		// to go back to being immutable once we are finished modifying it.
 		if ([self isCoreObjectCollection: collection])
 		{
@@ -975,7 +975,7 @@ See +[NSObject typePrefix]. */
 	
 	if ([self isCoreObjectCollection: collection])
 	{
-		[collection endTemporaryModification];
+		[collection endMutation];
 	}
 	
 	return collection;
@@ -1089,7 +1089,7 @@ See +[NSObject typePrefix]. */
 	[self pushProperty: key];
 	if ([self isCoreObjectCollection: oldValue])
 	{
-		[(id <COPrimitiveCollection>)oldValue beginTemporaryModification];
+		[(id <COPrimitiveCollection>)oldValue beginMutation];
 	}
 
 	// Used to be done in -commonDidChangeValueForProperty: when we kept a snapshot
@@ -1116,7 +1116,7 @@ See +[NSObject typePrefix]. */
 	[self pushProperty: key];
 	if ([self isCoreObjectCollection: oldValue])
 	{
-		[(id <COPrimitiveCollection>)oldValue beginTemporaryModification];
+		[(id <COPrimitiveCollection>)oldValue beginMutation];
 	}
 	
 	NSArray *replacedOrRemoved;
@@ -1505,7 +1505,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 	
 	if ([self isCoreObjectCollection: newValue])
 	{
-		[(id <COPrimitiveCollection>)newValue endTemporaryModification];
+		[(id <COPrimitiveCollection>)newValue endMutation];
 	}
 	else
 	{
@@ -1563,7 +1563,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 	// Fast path:
 	
 	[self popProperty: key];
-	[(id <COPrimitiveCollection>)newValue endTemporaryModification];
+	[(id <COPrimitiveCollection>)newValue endMutation];
 	
 	// We must figure out which objects were added, and which were replaced or removed
 	
@@ -1900,7 +1900,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 			COMutableArray *array = value;
 			const NSUInteger count = array.backing.count;
 
-			[array beginTemporaryModification];
+			[array beginMutation];
 			for (NSUInteger i=0; i<count; i++)
 			{
 				if ([[array referenceAtIndex: i] isEqual: object])
@@ -1915,13 +1915,13 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 					ETAssert([array referenceAtIndex: i] == replacement);
 				}
 			}
-			[array endTemporaryModification];
+			[array endMutation];
 		}
 		else if ([value isKindOfClass: [COMutableSet class]])
 		{
 			COMutableSet *set = value;
 			
-			[set beginTemporaryModification];
+			[set beginMutation];
 			if ([set containsReference: object])
 			{
 				if (!updated)
@@ -1933,7 +1933,7 @@ conformsToPropertyDescription: (ETPropertyDescription *)propertyDesc
 				[set addReference: replacement];
 				ETAssert([set containsReference: replacement]);
 			}
-			[set endTemporaryModification];
+			[set endMutation];
 		}
 		else if ([value isEqual: object])
 		{

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -22,14 +22,17 @@
 
 
 @protocol COPrimitiveCollection <NSObject>
-@property (nonatomic, getter=isMutable) BOOL mutable;
+- (void) beginTemporaryModification;
+- (void) endTemporaryModification;
+@property (nonatomic, readonly) BOOL isMutable;
 @property (nonatomic, readonly) id <NSFastEnumeration> enumerableReferences;
 @end
 
 @interface COMutableSet : NSMutableSet <COPrimitiveCollection>
 {
 	@public
-	BOOL _mutable;
+	BOOL _permanentlyMutable;
+	int _temporaryMutable;
 	NSHashTable *_backing;
 	NSHashTable *_deadReferences;
 }
@@ -47,7 +50,8 @@
 @interface COMutableArray : NSMutableArray <COPrimitiveCollection>
 {
 @public
-	BOOL _mutable;
+	BOOL _permanentlyMutable;
+	int _temporaryMutable;
 	NSPointerArray *_backing;
 	/**
 	 * Array of integers, the ith entry gives the backing index for
@@ -78,7 +82,8 @@
 @interface COMutableDictionary : NSMutableDictionary <COPrimitiveCollection>
 {
 	@public
-	BOOL _mutable;
+	BOOL _permanentlyMutable;
+	int _temporaryMutable;
 	NSMutableDictionary *_backing;
 	NSMutableSet *_deadKeys;
 }

--- a/Core/COPrimitiveCollection.h
+++ b/Core/COPrimitiveCollection.h
@@ -22,8 +22,8 @@
 
 
 @protocol COPrimitiveCollection <NSObject>
-- (void) beginTemporaryModification;
-- (void) endTemporaryModification;
+- (void) beginMutation;
+- (void) endMutation;
 @property (nonatomic, readonly) BOOL isMutable;
 @property (nonatomic, readonly) id <NSFastEnumeration> enumerableReferences;
 @end

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -52,12 +52,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 @synthesize backing = _backing;
 
-- (void) beginTemporaryModification
+- (void) beginMutation
 {
 	_temporaryMutable++;
 }
 
-- (void) endTemporaryModification
+- (void) endMutation
 {
 	_temporaryMutable--;
 	if (_temporaryMutable < 0)
@@ -91,12 +91,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	_backing = [self makeBacking];
 	_externalIndexToBackingIndex = [NSPointerArray pointerArrayWithOptions:NSPointerFunctionsOpaqueMemory | NSPointerFunctionsIntegerPersonality];
 	
-	[self beginTemporaryModification];
+	[self beginMutation];
 	for (NSUInteger i=0; i<count; i++)
 	{
 		[self addReference: objects[i]];
 	}
-	[self endTemporaryModification];
+	[self endMutation];
 
 	return self;
 }
@@ -464,12 +464,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 @implementation COMutableSet
 
-- (void) beginTemporaryModification
+- (void) beginMutation
 {
 	_temporaryMutable++;
 }
 
-- (void) endTemporaryModification
+- (void) endMutation
 {
 	_temporaryMutable--;
 	if (_temporaryMutable < 0)
@@ -499,12 +499,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	_backing = [self makeBacking];
 	_deadReferences = [NSHashTable new];
 
-	[self beginTemporaryModification];
+	[self beginMutation];
 	for (NSUInteger i=0; i<count; i++)
 	{
 		[self addReference: objects[i]];
 	}
-	[self endTemporaryModification];
+	[self endMutation];
 
 	return self;
 }
@@ -627,12 +627,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 @implementation COMutableDictionary
 
-- (void) beginTemporaryModification
+- (void) beginMutation
 {
 	_temporaryMutable++;
 }
 
-- (void) endTemporaryModification
+- (void) endMutation
 {
 	_temporaryMutable--;
 	if (_temporaryMutable < 0)
@@ -657,12 +657,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	_backing = [[NSMutableDictionary alloc] initWithCapacity: count];
 	_deadKeys = [NSMutableSet new];
 	
-	[self beginTemporaryModification];
+	[self beginMutation];
 	for (NSUInteger i=0; i<count; i++)
 	{
 		[self setReference: objects[i] forKey: keys[i]];
 	}
-	[self endTemporaryModification];
+	[self endMutation];
 
 	return self;
 }

--- a/Core/COPrimitiveCollection.m
+++ b/Core/COPrimitiveCollection.m
@@ -27,9 +27,9 @@ static inline BOOL COIsTombstone(NSObject *obj)
     return [obj isKindOfClass: [COPath class]];
 }
 
-static inline void COThrowExceptionIfNotMutable(BOOL mutable)
+static inline void COThrowExceptionIfNotMutable(BOOL permanent, int temp)
 {
-	if (!mutable)
+	if (!permanent && temp == 0)
 	{
 		[NSException raise: NSGenericException
 		            format: @"Attempted to modify an immutable collection"];
@@ -50,7 +50,26 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 @implementation COMutableArray
 
-@synthesize mutable = _mutable, backing = _backing;
+@synthesize backing = _backing;
+
+- (void) beginTemporaryModification
+{
+	_temporaryMutable++;
+}
+
+- (void) endTemporaryModification
+{
+	_temporaryMutable--;
+	if (_temporaryMutable < 0)
+	{
+		_temporaryMutable = 0;
+	}
+}
+
+- (BOOL) isMutable
+{
+	return _permanentlyMutable || _temporaryMutable > 0;
+}
 
 - (NSPointerArray *) makeBacking
 {
@@ -72,12 +91,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	_backing = [self makeBacking];
 	_externalIndexToBackingIndex = [NSPointerArray pointerArrayWithOptions:NSPointerFunctionsOpaqueMemory | NSPointerFunctionsIntegerPersonality];
 	
-	_mutable = YES;
+	[self beginTemporaryModification];
 	for (NSUInteger i=0; i<count; i++)
 	{
 		[self addReference: objects[i]];
 	}
-	_mutable = NO;
+	[self endTemporaryModification];
 
 	return self;
 }
@@ -93,7 +112,8 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	
 	newArray->_backing = [_backing copyWithZone: zone];
 	newArray->_externalIndexToBackingIndex = [_externalIndexToBackingIndex copyWithZone: zone];
-	newArray->_mutable = _mutable;
+	newArray->_permanentlyMutable = _permanentlyMutable;
+	newArray->_temporaryMutable = _temporaryMutable;
 
 	return newArray;
 }
@@ -101,7 +121,8 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 - (id)mutableCopyWithZone: (NSZone *)zone
 {
 	COMutableArray *newArray = [self copyWithZone: zone];
-	newArray->_mutable = YES;
+	newArray->_permanentlyMutable = YES;
+	newArray->_temporaryMutable = 0;
 	return newArray;
 }
 
@@ -117,7 +138,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)addReference: (id)aReference
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	if (!COIsTombstone(aReference))
 	{
 		[_externalIndexToBackingIndex addPointer: (void *)_backing.count];
@@ -156,7 +177,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)replaceReferenceAtIndex: (NSUInteger)index withReference: (id)aReference
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	
 	const BOOL wasTombstone = COIsTombstone((id)[_backing pointerAtIndex: index]);
 	const BOOL willBeTombstone = COIsTombstone(aReference);
@@ -209,7 +230,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)insertObject: (id)anObject atIndex: (NSUInteger)index
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	COThrowExceptionIfOutOfBounds(self, index, YES);
 	
 	ETAssert(!COIsTombstone(anObject));
@@ -248,7 +269,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)removeObjectAtIndex: (NSUInteger)index
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	COThrowExceptionIfOutOfBounds(self, index, NO);
 
 	NSUInteger backingIndex = [self backingIndex: index];
@@ -260,7 +281,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)replaceObjectAtIndex: (NSUInteger)index withObject: (id)anObject
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	COThrowExceptionIfOutOfBounds(self, index, NO);
 	ETAssert(!COIsTombstone(anObject));
 	[_backing replacePointerAtIndex: [self backingIndex: index]
@@ -272,7 +293,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 // from the diff. In this way, the dead references would shifted around more properly.
 - (void)setArray: (NSArray *)liveObjects
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 
 	NSArray *deadReferences = [_backing.allObjects filteredCollectionWithBlock: ^(id obj) {
 		return COIsTombstone(obj);
@@ -349,7 +370,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)addReference: (id)aReference
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 
 	// discard duplicates
 	if ([self checkPresentAndAddToHashTable: aReference])
@@ -366,7 +387,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)replaceReferenceAtIndex: (NSUInteger)index withReference: (id)aReference
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 
 	// discard duplicates
 	if ([self checkPresentAndAddToHashTable: aReference])
@@ -391,7 +412,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)insertObject: (id)anObject atIndex: (NSUInteger)index
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 
 	// discard duplicates
 	if ([self checkPresentAndAddToHashTable: anObject])
@@ -404,7 +425,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)removeObjectAtIndex: (NSUInteger)index
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	
 	// remove old value from hash table
 	[_backingHashTable removeObject: [self objectAtIndex: index]];
@@ -414,7 +435,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)replaceObjectAtIndex: (NSUInteger)index withObject: (id)anObject
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	
 	// discard duplicates
 	if ([self checkPresentAndAddToHashTable: anObject])
@@ -430,7 +451,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)setArray: (NSArray *)liveObjects
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 
 	// remove old values from hash table
 	[_backingHashTable removeAllObjects];
@@ -443,7 +464,24 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 @implementation COMutableSet
 
-@synthesize mutable = _mutable;
+- (void) beginTemporaryModification
+{
+	_temporaryMutable++;
+}
+
+- (void) endTemporaryModification
+{
+	_temporaryMutable--;
+	if (_temporaryMutable < 0)
+	{
+		_temporaryMutable = 0;
+	}
+}
+
+- (BOOL) isMutable
+{
+	return _permanentlyMutable || _temporaryMutable > 0;
+}
 
 - (NSHashTable *) makeBacking
 {
@@ -461,12 +499,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	_backing = [self makeBacking];
 	_deadReferences = [NSHashTable new];
 
-	_mutable = YES;
+	[self beginTemporaryModification];
 	for (NSUInteger i=0; i<count; i++)
 	{
 		[self addReference: objects[i]];
 	}
-	_mutable = NO;
+	[self endTemporaryModification];
 
 	return self;
 }
@@ -481,7 +519,8 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	
 	newSet->_backing = [_backing copyWithZone: zone];
 	newSet->_deadReferences = [_deadReferences copyWithZone: zone];
-	newSet->_mutable = _mutable;
+	newSet->_permanentlyMutable = _permanentlyMutable;
+	newSet->_temporaryMutable = _temporaryMutable;
 	
 	return newSet;
 }
@@ -489,7 +528,8 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 - (id)mutableCopyWithZone: (NSZone *)zone
 {
 	COMutableSet *newSet = [self copyWithZone: zone];
-	newSet->_mutable = YES;
+	newSet->_permanentlyMutable = YES;
+	newSet->_temporaryMutable = 0;
 	return newSet;
 }
 
@@ -500,7 +540,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)addReference: (id)aReference
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	[_backing addObject: aReference];
 	if (COIsTombstone(aReference))
 	{
@@ -510,7 +550,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)removeReference: (id)aReference
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	[_backing removeObject: aReference];
 	if (COIsTombstone(aReference))
 	{
@@ -555,7 +595,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)addObject: (id)anObject
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	ETAssert(!COIsTombstone(anObject));
 		
 	[_backing addObject: anObject];
@@ -563,7 +603,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)removeObject: (id)anObject
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	ETAssert(!COIsTombstone(anObject));
 	
 	[_backing removeObject: anObject];
@@ -587,7 +627,24 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 @implementation COMutableDictionary
 
-@synthesize mutable = _mutable;
+- (void) beginTemporaryModification
+{
+	_temporaryMutable++;
+}
+
+- (void) endTemporaryModification
+{
+	_temporaryMutable--;
+	if (_temporaryMutable < 0)
+	{
+		_temporaryMutable = 0;
+	}
+}
+
+- (BOOL) isMutable
+{
+	return _permanentlyMutable || _temporaryMutable > 0;
+}
 
 - (instancetype)init
 {
@@ -600,12 +657,12 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	_backing = [[NSMutableDictionary alloc] initWithCapacity: count];
 	_deadKeys = [NSMutableSet new];
 	
-	_mutable = YES;
+	[self beginTemporaryModification];
 	for (NSUInteger i=0; i<count; i++)
 	{
 		[self setReference: objects[i] forKey: keys[i]];
 	}
-	_mutable = NO;
+	[self endTemporaryModification];
 
 	return self;
 }
@@ -621,7 +678,8 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 	
 	newDictionary->_backing = [_backing copyWithZone: zone];
 	newDictionary->_deadKeys = [_deadKeys copyWithZone: zone];
-	newDictionary->_mutable = _mutable;
+	newDictionary->_permanentlyMutable = _permanentlyMutable;
+	newDictionary->_temporaryMutable = _temporaryMutable;
 	
 	return newDictionary;
 }
@@ -629,7 +687,8 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 - (id)mutableCopyWithZone: (NSZone *)zone
 {
 	COMutableDictionary *newDictionary = [self copyWithZone: zone];
-	newDictionary->_mutable = YES;
+	newDictionary->_permanentlyMutable = YES;
+	newDictionary->_temporaryMutable = 0;
 	return newDictionary;
 }
 
@@ -640,7 +699,7 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)setReference: (id)aReference forKey: (id<NSCopying>)aKey
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	if (COIsTombstone(aReference))
 	{
 		[_deadKeys addObject: aKey];
@@ -681,13 +740,13 @@ static inline void COThrowExceptionIfOutOfBounds(COMutableArray *self, NSUIntege
 
 - (void)removeObjectForKey: (id)aKey
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	[_backing removeObjectForKey: aKey];
 }
 
 - (void)setObject: (id)anObject forKey: (id <NSCopying>)aKey
 {
-	COThrowExceptionIfNotMutable(_mutable);
+	COThrowExceptionIfNotMutable(_permanentlyMutable, _temporaryMutable);
 	[_backing setObject: anObject forKey: aKey];
 }
 

--- a/Core/COSerialization.m
+++ b/Core/COSerialization.m
@@ -702,7 +702,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 		COMutableArray *resultCollection =
 			[[self coreObjectCollectionClassForPropertyDescription: aPropertyDesc] new];
 		
-		[resultCollection beginTemporaryModification];
+		[resultCollection beginMutation];
 		for (id subvalue in value)
 		{
 			id deserializedValue = [self valueForSerializedValue: subvalue
@@ -711,7 +711,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 			
 			[resultCollection addReference: deserializedValue];
 		}
-		[resultCollection endTemporaryModification];
+		[resultCollection endMutation];
 
 		return resultCollection;
 	}
@@ -723,7 +723,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 		COMutableSet *resultCollection =
 			[[self coreObjectCollectionClassForPropertyDescription: aPropertyDesc] new];
 		
-		[resultCollection beginTemporaryModification];
+		[resultCollection beginMutation];
 		for (id subvalue in value)
 		{
 			id deserializedValue = [self valueForSerializedValue: subvalue
@@ -732,7 +732,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 
 			[resultCollection addReference: deserializedValue];
 		}
-		[resultCollection endTemporaryModification];
+		[resultCollection endMutation];
 
 		return resultCollection;
 	}

--- a/Core/COSerialization.m
+++ b/Core/COSerialization.m
@@ -702,7 +702,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 		COMutableArray *resultCollection =
 			[[self coreObjectCollectionClassForPropertyDescription: aPropertyDesc] new];
 		
-		resultCollection.mutable = YES;
+		[resultCollection beginTemporaryModification];
 		for (id subvalue in value)
 		{
 			id deserializedValue = [self valueForSerializedValue: subvalue
@@ -711,7 +711,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 			
 			[resultCollection addReference: deserializedValue];
 		}
-		resultCollection.mutable = NO;
+		[resultCollection endTemporaryModification];
 
 		return resultCollection;
 	}
@@ -723,7 +723,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 		COMutableSet *resultCollection =
 			[[self coreObjectCollectionClassForPropertyDescription: aPropertyDesc] new];
 		
-		resultCollection.mutable = YES;
+		[resultCollection beginTemporaryModification];
 		for (id subvalue in value)
 		{
 			id deserializedValue = [self valueForSerializedValue: subvalue
@@ -732,7 +732,7 @@ multivaluedPropertyDescription: (ETPropertyDescription *)aPropertyDesc
 
 			[resultCollection addReference: deserializedValue];
 		}
-		resultCollection.mutable = NO;
+		[resultCollection endTemporaryModification];
 
 		return resultCollection;
 	}

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -85,7 +85,7 @@
 {
 	SUPERINIT;
 	array = [COMutableArray new];
-	[array beginTemporaryModification];
+	[array beginMutation];
 	alive1 = @"alive1";
 	alive2 = @"alive2";
 	alive3 = @"alive3";
@@ -537,28 +537,28 @@
 
 - (void)testTemporaryMutation
 {
-	UKTrue(array.isMutable); // We called -beginTemporaryModification in -init
+	UKTrue(array.isMutable); // We called -beginMutation in -init
 	UKDoesNotRaiseException([array addObject: @"a"]);
-	[array endTemporaryModification];
+	[array endMutation];
 	
 	UKFalse(array.isMutable);
 	UKRaisesException([array addObject: @"a"]);
 	
-	// Now test two -beginTemporaryModification calls
-	[array beginTemporaryModification];
-	[array beginTemporaryModification];
+	// Now test two -beginMutation calls
+	[array beginMutation];
+	[array beginMutation];
 	
-	// Maknig a copy should preserve the "level" of -beginTemporaryModification calls
+	// Maknig a copy should preserve the "level" of -beginMutation calls
 	COMutableArray *arrayCopy = [array copy];
 	UKTrue(arrayCopy.isMutable);
 	UKDoesNotRaiseException([arrayCopy addObject: @"a"]);
 	
-	[arrayCopy endTemporaryModification];
+	[arrayCopy endMutation];
 	
 	UKTrue(arrayCopy.isMutable);
 	UKDoesNotRaiseException([arrayCopy addObject: @"a"]);
 	
-	[arrayCopy endTemporaryModification];
+	[arrayCopy endMutation];
 	
 	UKFalse(arrayCopy.isMutable);
 	UKRaisesException([arrayCopy addObject: @"a"]);
@@ -585,7 +585,7 @@
 {
 	SUPERINIT;
 	set = [COMutableSet new];
-	[set beginTemporaryModification];
+	[set beginMutation];
 	alive1 = @"alive1";
 	alive2 = @"alive2";
 	dead1 = [COPath pathWithPersistentRoot: [ETUUID UUID]];
@@ -759,28 +759,28 @@
 
 - (void)testTemporaryMutation
 {
-	UKTrue(set.isMutable); // We called -beginTemporaryModification in -init
+	UKTrue(set.isMutable); // We called -beginMutation in -init
 	UKDoesNotRaiseException([set addObject: @"a"]);
-	[set endTemporaryModification];
+	[set endMutation];
 	
 	UKFalse(set.isMutable);
 	UKRaisesException([set addObject: @"a"]);
 	
-	// Now test two -beginTemporaryModification calls
-	[set beginTemporaryModification];
-	[set beginTemporaryModification];
+	// Now test two -beginMutation calls
+	[set beginMutation];
+	[set beginMutation];
 	
-	// Maknig a copy should preserve the "level" of -beginTemporaryModification calls
+	// Maknig a copy should preserve the "level" of -beginMutation calls
 	COMutableArray *setCopy = [set copy];
 	UKTrue(setCopy.isMutable);
 	UKDoesNotRaiseException([setCopy addObject: @"a"]);
 	
-	[setCopy endTemporaryModification];
+	[setCopy endMutation];
 	
 	UKTrue(setCopy.isMutable);
 	UKDoesNotRaiseException([setCopy addObject: @"a"]);
 	
-	[setCopy endTemporaryModification];
+	[setCopy endMutation];
 	
 	UKFalse(setCopy.isMutable);
 	UKRaisesException([setCopy addObject: @"a"]);
@@ -804,7 +804,7 @@
 {
 	SUPERINIT;
 	array = [COUnsafeRetainedMutableArray new];
-	[array beginTemporaryModification];
+	[array beginMutation];
 	return self;
 }
 
@@ -912,7 +912,7 @@
 {
 	SUPERINIT;
 	set = [COUnsafeRetainedMutableSet new];
-	[set beginTemporaryModification];
+	[set beginMutation];
 	return self;
 }
 

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -85,7 +85,7 @@
 {
 	SUPERINIT;
 	array = [COMutableArray new];
-	array.mutable = YES;
+	[array beginTemporaryModification];
 	alive1 = @"alive1";
 	alive2 = @"alive2";
 	alive3 = @"alive3";
@@ -535,6 +535,35 @@
 	UKDoesNotRaiseException([array removeLastObject]);
 }
 
+- (void)testTemporaryMutation
+{
+	UKTrue(array.isMutable); // We called -beginTemporaryModification in -init
+	UKDoesNotRaiseException([array addObject: @"a"]);
+	[array endTemporaryModification];
+	
+	UKFalse(array.isMutable);
+	UKRaisesException([array addObject: @"a"]);
+	
+	// Now test two -beginTemporaryModification calls
+	[array beginTemporaryModification];
+	[array beginTemporaryModification];
+	
+	// Maknig a copy should preserve the "level" of -beginTemporaryModification calls
+	COMutableArray *arrayCopy = [array copy];
+	UKTrue(arrayCopy.isMutable);
+	UKDoesNotRaiseException([arrayCopy addObject: @"a"]);
+	
+	[arrayCopy endTemporaryModification];
+	
+	UKTrue(arrayCopy.isMutable);
+	UKDoesNotRaiseException([arrayCopy addObject: @"a"]);
+	
+	[arrayCopy endTemporaryModification];
+	
+	UKFalse(arrayCopy.isMutable);
+	UKRaisesException([arrayCopy addObject: @"a"]);
+}
+
 @end
 
 #pragma mark - TestMutableSet
@@ -556,7 +585,7 @@
 {
 	SUPERINIT;
 	set = [COMutableSet new];
-	set.mutable = YES;
+	[set beginTemporaryModification];
 	alive1 = @"alive1";
 	alive2 = @"alive2";
 	dead1 = [COPath pathWithPersistentRoot: [ETUUID UUID]];
@@ -728,6 +757,35 @@
 	UKIntsEqual(0, set.count);
 }
 
+- (void)testTemporaryMutation
+{
+	UKTrue(set.isMutable); // We called -beginTemporaryModification in -init
+	UKDoesNotRaiseException([set addObject: @"a"]);
+	[set endTemporaryModification];
+	
+	UKFalse(set.isMutable);
+	UKRaisesException([set addObject: @"a"]);
+	
+	// Now test two -beginTemporaryModification calls
+	[set beginTemporaryModification];
+	[set beginTemporaryModification];
+	
+	// Maknig a copy should preserve the "level" of -beginTemporaryModification calls
+	COMutableArray *setCopy = [set copy];
+	UKTrue(setCopy.isMutable);
+	UKDoesNotRaiseException([setCopy addObject: @"a"]);
+	
+	[setCopy endTemporaryModification];
+	
+	UKTrue(setCopy.isMutable);
+	UKDoesNotRaiseException([setCopy addObject: @"a"]);
+	
+	[setCopy endTemporaryModification];
+	
+	UKFalse(setCopy.isMutable);
+	UKRaisesException([setCopy addObject: @"a"]);
+}
+
 @end
 
 
@@ -746,7 +804,7 @@
 {
 	SUPERINIT;
 	array = [COUnsafeRetainedMutableArray new];
-	array.mutable = YES;
+	[array beginTemporaryModification];
 	return self;
 }
 
@@ -854,7 +912,7 @@
 {
 	SUPERINIT;
 	set = [COUnsafeRetainedMutableSet new];
-	set.mutable = YES;
+	[set beginTemporaryModification];
 	return self;
 }
 

--- a/Tests/Core/TestPrimitiveCollection.m
+++ b/Tests/Core/TestPrimitiveCollection.m
@@ -548,7 +548,7 @@
 	[array beginMutation];
 	[array beginMutation];
 	
-	// Maknig a copy should preserve the "level" of -beginMutation calls
+	// Making a copy should preserve the "level" of -beginMutation calls
 	COMutableArray *arrayCopy = [array copy];
 	UKTrue(arrayCopy.isMutable);
 	UKDoesNotRaiseException([arrayCopy addObject: @"a"]);
@@ -770,7 +770,7 @@
 	[set beginMutation];
 	[set beginMutation];
 	
-	// Maknig a copy should preserve the "level" of -beginMutation calls
+	// Making a copy should preserve the "level" of -beginMutation calls
 	COMutableArray *setCopy = [set copy];
 	UKTrue(setCopy.isMutable);
 	UKDoesNotRaiseException([setCopy addObject: @"a"]);


### PR DESCRIPTION
- now there are a pair of -beginTemporaryModification and -endTemporaryModification calls that support nesting properly.
- -mutableCopy returns an instance that is always mutable.

This is something I'll need for the persistent root lazy loading, but it's also cleaner IMO.