### PR TITLE
Custom migration support

### DIFF
--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -153,6 +153,7 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
 	@private
 	COSQLiteStore *_store;
 	ETModelDescriptionRepository *_modelDescriptionRepository;
+	Class _migrationDriverClass;
 	/** Loaded (or inserted) persistent roots by UUID */
 	NSMutableDictionary *_loadedPersistentRoots;
 	COEditingContextUnloadingBehavior _unloadingBehavior;
@@ -194,8 +195,8 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
 /**
  * <init />
  * Initializes a context which persists its content in the given store,
- * manages it using the metamodel provided by the model description repository, 
- * and whose undo tracks are backed by the last store argument.
+ * manages it using the metamodel provided by the model description repository 
+ * and migration driver, and whose undo tracks are backed by the last store argument.
  *
  * When COObject entity description doesn't appear in the repository, this 
  * initializer invokes +newEntityDescription on COObject and its subclasses, 
@@ -212,10 +213,14 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
  * For a nil model repository, or a repository that doesn't a COObject entity
  * description, raises a NSInvalidArgumentException.
  *
+ * For a migration driver class that is not a subclass of COSchemaMigrationDriver, 
+ * raises a NSInvalidArgumentException.
+ *
  * For a nil undo track store, raises a NSInvalidArgumentException.
  */
 - (instancetype)initWithStore: (COSQLiteStore *)store
    modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+         migrationDriverClass: (Class)aDriverClass
                undoTrackStore: (COUndoTrackStore *)aUndoTrackStore;
 /**
  * Initializes a context which persists its content in the given store, and
@@ -273,9 +278,19 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
  */
 @property (nonatomic, readonly, strong) ETModelDescriptionRepository *modelDescriptionRepository;
 /**
+ * The migration driver used to migrate items to the latest package versions.
+ *
+ * By default, returns COSchemaMigrationDriver.
+ *
+ * You should usually use COSchemaMigration rather than writing your own custom 
+ * migration driver subclass.
+ */
+@property (nonatomic, readonly) Class migrationDriverClass;
+/**
  * Returns the store backing the undo tracks initialized with the receiver.
  */
 @property (nonatomic, readonly, strong) COUndoTrackStore *undoTrackStore;
+
 
 
 /** @taskunit Managing Persistent Roots */

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -32,6 +32,7 @@
 @implementation COEditingContext
 
 @synthesize store = _store, modelDescriptionRepository = _modelDescriptionRepository;
+@synthesize migrationDriverClass = _migrationDriverClass;
 @synthesize unloadingBehavior = _unloadingBehavior;
 @synthesize persistentRootsPendingDeletion = _persistentRootsPendingDeletion;
 @synthesize persistentRootsPendingUndeletion = _persistentRootsPendingUndeletion;
@@ -48,17 +49,21 @@
 
 - (instancetype)initWithStore: (COSQLiteStore *)store
    modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+         migrationDriverClass: (Class)aDriverClass
                undoTrackStore: (COUndoTrackStore *)anUndoTrackStore
 {
 	NILARG_EXCEPTION_TEST(store);
 	NILARG_EXCEPTION_TEST(aRepo);
-	NILARG_EXCEPTION_TEST(anUndoTrackStore);
 	INVALIDARG_EXCEPTION_TEST(aRepo, [aRepo entityDescriptionForClass: [COObject class]] != nil);
+	INVALIDARG_EXCEPTION_TEST(aDriverClass, [aDriverClass isSubclassOfClass: [COSchemaMigrationDriver class]]);
+	NILARG_EXCEPTION_TEST(anUndoTrackStore);
+
 
 	SUPERINIT;
 
 	_store =  store;
 	_modelDescriptionRepository = aRepo;
+	_migrationDriverClass = aDriverClass;
 	_loadedPersistentRoots = [NSMutableDictionary new];
 	_unloadingBehavior = COEditingContextUnloadingBehaviorOnDeletion;
 	_persistentRootsPendingDeletion = [NSMutableSet new];
@@ -67,7 +72,9 @@
 	_undoTrackStore = anUndoTrackStore;
     _isRecordingUndo = YES;
 	_revisionCache = [[CORevisionCache alloc] initWithParentEditingContext: self];
-	_internalTransientObjectGraphContext = [[COObjectGraphContext alloc] initWithModelDescriptionRepository: aRepo];
+	_internalTransientObjectGraphContext = [[COObjectGraphContext alloc]
+		initWithModelDescriptionRepository: aRepo
+		              migrationDriverClass: aDriverClass];
 	_lastTransactionIDForPersistentRootUUID = [NSMutableDictionary new];
 	CORegisterCoreObjectMetamodel(_modelDescriptionRepository);
 
@@ -95,6 +102,7 @@
 {
 	return [self initWithStore: store
 	modelDescriptionRepository: aRepo
+	      migrationDriverClass: [COSchemaMigrationDriver class]
 	            undoTrackStore: [COUndoTrackStore defaultStore]];
 }
 

--- a/Core/COObjectGraphContext.h
+++ b/Core/COObjectGraphContext.h
@@ -172,6 +172,7 @@ extern NSString * const COObjectGraphContextEndBatchChangeNotification;
 {
 	@private
 	ETModelDescriptionRepository *_modelDescriptionRepository;
+	Class _migrationDriverClass;
 	COBranch *__weak _branch;
 	COPersistentRoot *__weak _persistentRoot;
 	ETUUID *_futureBranchUUID;
@@ -257,7 +258,7 @@ extern NSString * const COObjectGraphContextEndBatchChangeNotification;
 @property (nonatomic, readonly) BOOL isObjectGraphContext;
 
 
-/** @taskunit Metamodel Access */
+/** @taskunit Metamodel Access and Migration Support */
 
 
 /**
@@ -265,7 +266,16 @@ extern NSString * const COObjectGraphContextEndBatchChangeNotification;
  * describes all the objects managed by the context.
  */
 @property (nonatomic, readonly) ETModelDescriptionRepository *modelDescriptionRepository;
-@property (nonatomic, readonly) int64_t schemaVersion;
+/**
+ * The migration driver used to migrate items to the latest package versions.
+ *
+ * By default, returns COSchemaMigrationDriver.
+ *
+ * You should usually use COSchemaMigration rather than writing your own custom 
+ * migration driver subclass.
+ */
+@property (nonatomic, strong) Class migrationDriverClass;
+
 
 /** @taskunit Related Persistency Management Objects */
 

--- a/Core/COObjectGraphContext.h
+++ b/Core/COObjectGraphContext.h
@@ -213,7 +213,7 @@ extern NSString * const COObjectGraphContextEndBatchChangeNotification;
 - (id)initWithBranch: (COBranch *)aBranch;
 /**
  * Initializes a transient object graph context using the given model
- * description repository.
+ * description repository and migration driver.
  *
  * To register your metamodel in the model description repository, see
  * -[COEditingContext initWithStore:modelDescriptionRepository:]. This 
@@ -222,8 +222,14 @@ extern NSString * const COObjectGraphContextEndBatchChangeNotification;
  * If you intend to pass the object graph to 
  * -[COEditingContext insertNewPersistentRootWithRootObject:], the repository 
  * must be the same than the one used by the editing context.
+ *
+ * For a nil model description repository, raises a NSInvalidArgumentException.
+ *
+ * For a migration driver class that is neither nil nor a subclass of 
+ * COSchemaMigrationDriver, raises a NSInvalidArgumentException.
  */
-- (id)initWithModelDescriptionRepository: (ETModelDescriptionRepository *)aRepo;
+- (id)initWithModelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+                    migrationDriverClass: (Class)aDriverClass;
 /**
  * Returns a new transient object graph context using the main model description 
  * repository.
@@ -269,12 +275,9 @@ extern NSString * const COObjectGraphContextEndBatchChangeNotification;
 /**
  * The migration driver used to migrate items to the latest package versions.
  *
- * By default, returns COSchemaMigrationDriver.
- *
- * You should usually use COSchemaMigration rather than writing your own custom 
- * migration driver subclass.
+ * For more details, see -[COEditingContext migrationDriverClass].
  */
-@property (nonatomic, strong) Class migrationDriverClass;
+@property (nonatomic, readonly) Class migrationDriverClass;
 
 
 /** @taskunit Related Persistency Management Objects */

--- a/Core/COObjectGraphContext.m
+++ b/Core/COObjectGraphContext.m
@@ -70,7 +70,10 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 
 - (id)initWithBranch: (COBranch *)aBranch
      modelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+	       migrationDriverClass: (Class)aDriverClass
 {
+	INVALIDARG_EXCEPTION_TEST(aDriverClass, aDriverClass == Nil || [aDriverClass isSubclassOfClass: [COSchemaMigrationDriver class]]);
+
     SUPERINIT;
     _loadedObjects = [[NSMutableDictionary alloc] init];
 	_objectsByAdditionalItemUUIDs = [[NSMutableDictionary alloc] init];
@@ -88,24 +91,39 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 	{
 		CORegisterCoreObjectMetamodel(aRepo);
 	}
-    _modelDescriptionRepository =  aRepo;
-	_migrationDriverClass = [COSchemaMigrationDriver class];
+    _modelDescriptionRepository = aRepo;
+	if (aDriverClass == Nil)
+	{
+		_migrationDriverClass = _persistentRoot.editingContext.migrationDriverClass;
+	}
+	else
+	{
+		_migrationDriverClass = aDriverClass;
+	}
+	
+	ETAssert(_modelDescriptionRepository != nil);
+	ETAssert(_migrationDriverClass != Nil);
+
     return self;
 }
 
 - (id)initWithBranch: (COBranch *)aBranch
 {
-    return [self initWithBranch: aBranch modelDescriptionRepository: nil];
+    return [self initWithBranch: aBranch modelDescriptionRepository: nil migrationDriverClass: Nil];
 }
 
 - (id)initWithModelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
+                    migrationDriverClass: (Class)aDriverClass
 {
-    return [self initWithBranch: nil modelDescriptionRepository: aRepo];
+	NILARG_EXCEPTION_TEST(aRepo);
+	NILARG_EXCEPTION_TEST(aDriverClass);
+    return [self initWithBranch: nil modelDescriptionRepository: aRepo migrationDriverClass: aDriverClass];
 }
 
 - (id)init
 {
-    return [self initWithModelDescriptionRepository: [ETModelDescriptionRepository mainRepository]];
+    return [self initWithModelDescriptionRepository: [ETModelDescriptionRepository mainRepository]
+	                           migrationDriverClass: [COSchemaMigrationDriver class]];
 }
 
 + (COObjectGraphContext *)objectGraphContext
@@ -115,7 +133,8 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 
 + (COObjectGraphContext *)objectGraphContextWithModelDescriptionRepository: (ETModelDescriptionRepository *)aRepo
 {
-    return [[self alloc] initWithModelDescriptionRepository: aRepo];
+    return [[self alloc] initWithModelDescriptionRepository: aRepo
+	                                   migrationDriverClass: [COSchemaMigrationDriver class]];
 }
 
 - (void)dealloc

--- a/Core/COObjectGraphContext.m
+++ b/Core/COObjectGraphContext.m
@@ -15,7 +15,7 @@
 #import "COObject+RelationshipCache.h"
 #import "COMetamodel.h"
 #import "COSerialization.h"
-#import "COSchemaMigration.h"
+#import "COSchemaMigrationDriver.h"
 #import "COPersistentRoot.h"
 #import "COBranch.h"
 #import "COBranch+Private.h"
@@ -64,6 +64,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 @synthesize modelDescriptionRepository = _modelDescriptionRepository;
 @synthesize insertedObjectUUIDs = _insertedObjectUUIDs;
 @synthesize updatedObjectUUIDs = _updatedObjectUUIDs;
+@synthesize migrationDriverClass = _migrationDriverClass;
 
 #pragma mark Creation
 
@@ -88,6 +89,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 		CORegisterCoreObjectMetamodel(aRepo);
 	}
     _modelDescriptionRepository =  aRepo;
+	_migrationDriverClass = [COSchemaMigrationDriver class];
     return self;
 }
 
@@ -145,12 +147,6 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 - (BOOL)isObjectGraphContext
 {
 	return YES;
-}
-
-- (int64_t)schemaVersion
-{
-	COObject *rootObject = self.rootObject;
-	return (rootObject == nil ? 0 : (int64_t)rootObject.entityDescription.owner.version);
 }
 
 #pragma mark -
@@ -494,8 +490,9 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 	// We could also change -[COObjectGraphContext itemForUUID:] to search
 	// itemGraph during the loading rather than the loaded objects (but that's
 	// roughly the same than we do currently).
-	NSArray *migratedItems = [COSchemaMigration migrateItems: itemGraph.items
-	                          withModelDescriptionRepository: self.modelDescriptionRepository];
+	COSchemaMigrationDriver *migrationDriver = [[self.migrationDriverClass alloc]
+		initWithModelDescriptionRepository: self.modelDescriptionRepository];
+	NSArray *migratedItems = [migrationDriver migrateItems: itemGraph.items];
 	_loadingItemGraph = [[COItemGraph alloc] initWithItems: migratedItems
 	                                          rootItemUUID: itemGraph.rootItemUUID];
 	// TODO: Decide how we update the change tracking in regard to additional items.

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -108,8 +108,8 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	}
 	else
 	{
-		_currentBranchObjectGraph = [[COObjectGraphContext alloc]
-			initWithModelDescriptionRepository: aCtxt.modelDescriptionRepository];
+		_currentBranchObjectGraph = [COObjectGraphContext
+			objectGraphContextWithModelDescriptionRepository: aCtxt.modelDescriptionRepository];
 	}
 	[_currentBranchObjectGraph setPersistentRoot: self];
 	
@@ -895,8 +895,8 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 - (COObjectGraphContext *)objectGraphContextForPreviewingRevision: (CORevision *)aRevision
 {
-    COObjectGraphContext *ctx = [[COObjectGraphContext alloc]
-		initWithModelDescriptionRepository: [[self editingContext] modelDescriptionRepository]];
+    COObjectGraphContext *ctx = [COObjectGraphContext
+		objectGraphContextWithModelDescriptionRepository: self.editingContext.modelDescriptionRepository];
     id <COItemGraph> items = [[self store] itemGraphForRevisionUUID: [aRevision UUID]
 	                                                 persistentRoot: _UUID];
 

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -108,8 +108,9 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	}
 	else
 	{
-		_currentBranchObjectGraph = [COObjectGraphContext
-			objectGraphContextWithModelDescriptionRepository: aCtxt.modelDescriptionRepository];
+		_currentBranchObjectGraph = [[COObjectGraphContext alloc]
+			initWithModelDescriptionRepository: aCtxt.modelDescriptionRepository
+			              migrationDriverClass: aCtxt.migrationDriverClass];
 	}
 	[_currentBranchObjectGraph setPersistentRoot: self];
 	
@@ -895,8 +896,9 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 - (COObjectGraphContext *)objectGraphContextForPreviewingRevision: (CORevision *)aRevision
 {
-    COObjectGraphContext *ctx = [COObjectGraphContext
-		objectGraphContextWithModelDescriptionRepository: self.editingContext.modelDescriptionRepository];
+    COObjectGraphContext *ctx = [[COObjectGraphContext alloc]
+		initWithModelDescriptionRepository: self.editingContext.modelDescriptionRepository
+		              migrationDriverClass: self.editingContext.migrationDriverClass];
     id <COItemGraph> items = [[self store] itemGraphForRevisionUUID: [aRevision UUID]
 	                                                 persistentRoot: _UUID];
 

--- a/CoreObject.h
+++ b/CoreObject.h
@@ -21,6 +21,7 @@
 /* Schema Migration */
 
 #import <CoreObject/COSchemaMigration.h>
+#import <CoreObject/COSchemaMigrationDriver.h>
 #import <CoreObject/COModelElementMove.h>
 
 /* Model */

--- a/CoreObject.xcodeproj/project.pbxproj
+++ b/CoreObject.xcodeproj/project.pbxproj
@@ -160,7 +160,7 @@
 		609CB4D01A5E9384003E8052 /* COTopologicalSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 609CB4CD1A5E9384003E8052 /* COTopologicalSort.h */; };
 		609CB4D11A5E9384003E8052 /* COTopologicalSort.m in Sources */ = {isa = PBXBuildFile; fileRef = 609CB4CE1A5E9384003E8052 /* COTopologicalSort.m */; };
 		609CB4D21A5E9384003E8052 /* COTopologicalSort.m in Sources */ = {isa = PBXBuildFile; fileRef = 609CB4CE1A5E9384003E8052 /* COTopologicalSort.m */; };
-		60AA7EB11A641FCD00897498 /* COSchemaMigrationDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 60FA55DE1A447A8600A2D8A7 /* COSchemaMigrationDriver.h */; };
+		60AA7EB11A641FCD00897498 /* COSchemaMigrationDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 60FA55DE1A447A8600A2D8A7 /* COSchemaMigrationDriver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60AA7EBC1A641FDE00897498 /* COSchemaMigrationDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FA55DF1A447A8600A2D8A7 /* COSchemaMigrationDriver.m */; };
 		60AD2F521B0A5BB000A9F473 /* TestPrimitiveCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AD2F511B0A5BB000A9F473 /* TestPrimitiveCollection.m */; };
 		60AD2F531B0A5BB000A9F473 /* TestPrimitiveCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AD2F511B0A5BB000A9F473 /* TestPrimitiveCollection.m */; };
@@ -508,7 +508,7 @@
 		60F91F39197D32F2009F47D7 /* 1a.json in Resources */ = {isa = PBXBuildFile; fileRef = 664E075C18C9592700CBFF74 /* 1a.json */; };
 		60F91F3A197D32F2009F47D7 /* 1b.json in Resources */ = {isa = PBXBuildFile; fileRef = 664E075D18C9592700CBFF74 /* 1b.json */; };
 		60F91F3B197D32FF009F47D7 /* Commits in Resources */ = {isa = PBXBuildFile; fileRef = 669A728D1885C43B00E98795 /* Commits */; };
-		60FA55E01A447A8600A2D8A7 /* COSchemaMigrationDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 60FA55DE1A447A8600A2D8A7 /* COSchemaMigrationDriver.h */; };
+		60FA55E01A447A8600A2D8A7 /* COSchemaMigrationDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 60FA55DE1A447A8600A2D8A7 /* COSchemaMigrationDriver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60FA55E11A447A8600A2D8A7 /* COSchemaMigrationDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 60FA55DF1A447A8600A2D8A7 /* COSchemaMigrationDriver.m */; };
 		60FB09D313C3079000C2AB94 /* EtoileFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60FB087D13C3066300C2AB94 /* EtoileFoundation.framework */; };
 		660179C8182AFA4B006E7D7B /* COSynchronizerRevision.h in Headers */ = {isa = PBXBuildFile; fileRef = 660179C6182AFA4B006E7D7B /* COSynchronizerRevision.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/SchemaMigration/COSchemaMigration.h
+++ b/SchemaMigration/COSchemaMigration.h
@@ -338,13 +338,6 @@ typedef NSArray *(^COMigrationBlock)(COSchemaMigration *migration, NSArray *stor
 + (NSArray *)migrations;
 
 
-/** @taskunit Migrating to Future Versions */
-
-
-+ (NSArray *)migrateItems: (NSArray *)storeItems
-withModelDescriptionRepository: (ETModelDescriptionRepository *)repo;
-
-
 /** @taskunit Targeted Versions */
 
 

--- a/SchemaMigration/COSchemaMigration.m
+++ b/SchemaMigration/COSchemaMigration.m
@@ -88,14 +88,6 @@ static NSMutableDictionary *dependencies;
 	return [migrations allValues];
 }
 
-#pragma mark - Triggering a Migration
-
-+ (NSArray *)migrateItems: (NSArray *)storeItems withModelDescriptionRepository: (ETModelDescriptionRepository *)repo
-{
-	return [[[COSchemaMigrationDriver alloc]
-		initWithModelDescriptionRepository: repo] migrateItems: storeItems];
-}
-
 #pragma mark Targeted Versions -
 
 - (int64_t)sourceVersion

--- a/SchemaMigration/COSchemaMigrationDriver.h
+++ b/SchemaMigration/COSchemaMigrationDriver.h
@@ -10,8 +10,33 @@
 
 @class COItem;
 
+
+/**
+ * @group Schema Migration
+ * @abstract A migration driver is a schema update mechanism operating on the 
+ * "semi-serialized" representation of COObject instances.
+ *
+ * @section Conceptual Model
+ *
+ * The driver processes a collection of COItem (representing a a partial or 
+ * entire object graph) with -migrateItems: through multiple COSchemaMigration.
+ *
+ * @section Common Use Cases
+ *
+ * You should almost never need to use this class directly. COSchemaMigration 
+ * can be used to write most migration cases in a way that is easier and safer.
+ *
+ * In some edge cases, like changing item entities/properties accross packages
+ * without altering the metamodel, COSchemaMigrationDriver can be subclassed 
+ * to override -migrateItems:, then set as -[COEditingContext migrationDriverClass].
+ *
+ * For example, this makes possible to recover from item graph creation mistakes
+ * when the metamodel doesn't require changes (e.g. forgetting to subclass an 
+ * entity located in another package).
+ */
 @interface COSchemaMigrationDriver : NSObject
 {
+	@private
 	ETModelDescriptionRepository *_modelDescriptionRepository;
 	NSMutableDictionary *itemsToMigrate;
 }

--- a/SchemaMigration/COSchemaMigrationDriver.h
+++ b/SchemaMigration/COSchemaMigrationDriver.h
@@ -55,6 +55,16 @@
 - (instancetype)initWithModelDescriptionRepository: (ETModelDescriptionRepository *)repo;
 
 
+/** @taskunit Metamodel Access */
+
+
+/**
+ * Returns the model description repository, that holds the metamodel to which
+ * items must be migrated to.
+ */
+@property (nonatomic, readonly) ETModelDescriptionRepository *modelDescriptionRepository;
+
+
 /** @taskunit Triggering a Migration */
 
 

--- a/SchemaMigration/COSchemaMigrationDriver.h
+++ b/SchemaMigration/COSchemaMigrationDriver.h
@@ -20,16 +20,29 @@
 /** @taskunit Initialization */
 
 
+/** 
+ * <init />
+ * Initializes a driver to migrate items to the metamodel in the given model 
+ * description repository.
+ *
+ * For a nil repository, raises a NSInvalidArgumentException.
+ */
 - (instancetype)initWithModelDescriptionRepository: (ETModelDescriptionRepository *)repo;
 
 
 /** @taskunit Triggering a Migration */
 
 
+/**
+ * Migrates the items to lastest package versions found in -modelDescriptionRepository.
+ *
+ * Can be overriden to implement a custom migration strategy.
+ */
 - (NSArray *)migrateItems: (NSArray *)storeItems;
 
 
 /** @taskunit Framework private */
+
 
 - (NSDictionary *) versionsByPackageNameForItem: (COItem *)item;
 

--- a/SchemaMigration/COSchemaMigrationDriver.m
+++ b/SchemaMigration/COSchemaMigrationDriver.m
@@ -28,6 +28,12 @@
 	return self;
 }
 
+- (instancetype)init
+{
+	[self doesNotRecognizeSelector: _cmd];
+	return nil;
+}
+
 #pragma mark Grouping Item by Packages -
 
 static inline void addObjectForKey(NSMutableDictionary *dict, id object, NSString *key)

--- a/SchemaMigration/COSchemaMigrationDriver.m
+++ b/SchemaMigration/COSchemaMigrationDriver.m
@@ -18,6 +18,8 @@
 
 @implementation COSchemaMigrationDriver
 
+@synthesize modelDescriptionRepository = _modelDescriptionRepository;
+
 #pragma mark Initialization -
 
 - (instancetype)initWithModelDescriptionRepository: (ETModelDescriptionRepository *)repo

--- a/Tests/Core/TestEditingContext.m
+++ b/Tests/Core/TestEditingContext.m
@@ -78,7 +78,7 @@
 	[newRepo setEntityDescription: rootEntity forClass: [COObject class]];
 
 	COObjectGraphContext *objectGraph =
-		[[COObjectGraphContext alloc] initWithModelDescriptionRepository: newRepo];
+		[COObjectGraphContext objectGraphContextWithModelDescriptionRepository: newRepo];
 	COObject *rootObject = [[COObject alloc] initWithObjectGraphContext: objectGraph];
 
 	UKObjectsNotEqual(newRepo, [ctx modelDescriptionRepository]);
@@ -272,6 +272,7 @@
 	                               modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]]);
 	UKRaisesException([[COEditingContext alloc] initWithStore: nil
 	                               modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]
+	                                     migrationDriverClass: [COSchemaMigrationDriver class]
 	                                           undoTrackStore: [COUndoTrackStore defaultStore]]);
 	UKRaisesException([[COEditingContext alloc] init]);
 }
@@ -281,6 +282,7 @@
 	// Will retain the store as argument but not release it due to the exception
 	UKRaisesException([[COEditingContext alloc] initWithStore: store
 	                               modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]
+	                                     migrationDriverClass: [COSchemaMigrationDriver class]
 	                                           undoTrackStore: nil]);
 }
 

--- a/Tests/TestCommon.m
+++ b/Tests/TestCommon.m
@@ -281,6 +281,7 @@ doesNotPostNotification: (NSString *)notif
 
 	ctx = [[COEditingContext alloc] initWithStore: store
 	                   modelDescriptionRepository: [ETModelDescriptionRepository mainRepository]
+	                         migrationDriverClass: [COSchemaMigrationDriver class]
 	                               undoTrackStore: undoStore];
     return self;
 }
@@ -333,6 +334,7 @@ doesNotPostNotification: (NSString *)notif
 {
     return [[COEditingContext alloc] initWithStore: [[COSQLiteStore alloc] initWithURL: ctx.store.URL]
                         modelDescriptionRepository: ctx.modelDescriptionRepository
+	                         migrationDriverClass: [COSchemaMigrationDriver class]
                                     undoTrackStore: ctx.undoTrackStore];
 }
 


### PR DESCRIPTION
The existing schema migration API works well 95% of the time when changing the schema, but in some special cases it's not enough and the item graph needs to be patched directly (e.g. to change items entities/properties accross packages without altering the metamodel). 

To do this, I have exposed COSchemaMigrationDriver API and made possible to initialize COObjectGraphContext with a custom driver subclass. A driver subclass can override `-migrateItems:` to implement a custom migrations strategy. Here is an example in Swift:

```
class PlaceboardMigrationDriver : COSchemaMigrationDriver {

	// For Placeboard 1.0.2 -> 1.0.3
	//
	// Forgot to subclass COTagLibrary entity located in CoreObject package when creating Placeboard metamodel, this migration fixes the item graph directly.
	func migrateTagLibrary(storeItems: [AnyObject]!) -> [AnyObject]! {
		
		// The guard clause below is equivalent to:
		// if storeItems.count != 1 || item.packageVersion != 0 || item.entityName != "COTagLibrary" { return storeItems }
		guard let item = storeItems.first
		    where storeItems.count == 1 && item.packageVersion == 0 && item.entityName == "COTagLibrary" else {
				return storeItems
		}
		precondition(item.packageName == "org.etoile-project.CoreObject")

		let newItem = item.mutableCopy() as! COMutableItem
		let package = modelDescriptionRepository.descriptionForName(NSBundle.mainBundle().bundleIdentifier) as! ETPackageDescription
			
		newItem.entityName = "PWTagLibrary"
		newItem.packageName = package.name
		newItem.packageVersion = Int64(package.version)
			
		return [newItem]
	}

	override func migrateItems(storeItems: [AnyObject]!) -> [AnyObject]! {
		let patchedItems = migrateTagLibrary(storeItems)

		return super.migrateItems(patchedItems)
	}
}
```

To create editing contexts that leverage the custom driver above:
```
		let ctx = COEditingContext(store: store,
		   modelDescriptionRepository: repo,
		         migrationDriverClass: PlaceboardMigrationDriver.self,
		               undoTrackStore: COUndoTrackStore(URL: undoTrackStoreURL))
```