### PR TITLE
Persistent root unloading

### DIFF
--- a/Core/COBranch.h
+++ b/Core/COBranch.h
@@ -304,7 +304,12 @@ extern NSString * const kCOBranchLabel;
  * Use it to cause a "checkpoint" revision to be written.
  */
 @property (nonatomic, assign) BOOL shouldMakeEmptyCommit;
-
+/**
+ * Returns whether the editing context has relinquished
+ * control over this object. If YES, this instance can no longer be used
+ * and calling any methods may throw an exception
+ */
+@property (nonatomic, readonly) BOOL isZombie;
 
 /** @taskunit Undo / Redo */
 

--- a/Core/COBranch.m
+++ b/Core/COBranch.m
@@ -113,6 +113,10 @@ parentRevisionForNewBranch: (ETUUID *)parentRevisionForNewBranch
 
 - (NSString *)description
 {
+	if ([self isZombie])
+	{
+		return @"<zombie branch>";
+	}
 	return [NSString stringWithFormat: @"<%@ %p - %@ (%@) - revision: %@>",
 		NSStringFromClass([self class]), self, _UUID, [self label], [[self currentRevision] UUID]];
 }
@@ -472,6 +476,11 @@ parentRevisionForNewBranch: (ETUUID *)parentRevisionForNewBranch
     self.shouldMakeEmptyCommit = NO;
     
 	[_objectGraph discardAllChanges];
+}
+
+- (BOOL) isZombie
+{
+	return (_persistentRoot == nil);
 }
 
 - (COBranch *)makeBranchWithLabel: (NSString *)aLabel

--- a/Core/COBranch.m
+++ b/Core/COBranch.m
@@ -167,7 +167,7 @@ parentRevisionForNewBranch: (ETUUID *)parentRevisionForNewBranch
 		// Lazy loading support
 		[self.editingContext updateCrossPersistentRootReferencesToPersistentRoot: self.persistentRoot
 																		  branch: self
-																	   isDeleted: self.deleted || self.persistentRoot.deleted];
+																	     isFault: self.deleted || self.persistentRoot.deleted];
 	}
 	return _objectGraph;
 }

--- a/Core/COEditingContext+Private.h
+++ b/Core/COEditingContext+Private.h
@@ -67,7 +67,7 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
  */
 - (void)updateCrossPersistentRootReferencesToPersistentRoot: (COPersistentRoot *)aPersistentRoot
                                                      branch: (COBranch *)aBranch
-                                                  isDeleted: (BOOL)isDeletion;
+                                                    isFault: (BOOL)faulting;
 /**
  * This method is only exposed to be used internally by CoreObject.
  */

--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -30,8 +30,8 @@
  */
 typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
 	/**
-	 * Persistent roots are never unloaded automatically, except uncommitted persistent roots on
-	 * deletion.
+	 * Persistent roots are never unloaded automatically, except uncommitted 
+	 * persistent roots on deletion.
 	 *
 	 * -unloadPersistentRoot: can still be used to unload persistent roots explicitly.
 	 */
@@ -313,6 +313,20 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
  * Same as -persistentRootForUUID: but doesn't cause loading.
  */
 - (COPersistentRoot *)loadedPersistentRootForUUID: (ETUUID *)aUUID;
+/**
+ * Unloads the persistent root including its branches, object graphs and inner
+ * objects.
+ *
+ * To reload a persistent root, use -persistentRootForUUID:.
+ *
+ * Cross persistent root references pointing to inner objects that belongs to 
+ * the unloaded persistent root will be turned into faults. Any future attempts
+ * to access them with -[COObject valueForProperty:] will cause this persistent 
+ * root to be transparently reloaded.
+ *
+ * See -[COEditingContext setUnloadingBehavior:] to control when persistent 
+ * roots are unloaded or prevent unloading to happen.
+ */
 - (void)unloadPersistentRoot: (COPersistentRoot *)aPersistentRoot;
 /**
  * Returns a new persistent root that uses the given root object.

--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -30,12 +30,14 @@
  */
 typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
 	/**
-	 * Persistent roots cannot be unloaded, except uncommitted persistent roots
-	 * on deletion.
+	 * Persistent roots are never unloaded automatically, except uncommitted persistent roots on
+	 * deletion.
+	 *
+	 * -unloadPersistentRoot: can still be used to unload persistent roots explicitly.
 	 */
-	COEditingContextUnloadingBehaviorNever,
+	COEditingContextUnloadingBehaviorManual,
 	/**
-	 * Persistent roots can be unloaded on deletion.
+	 * Persistent roots are unloaded on deletion.
 	 *
      * For external deletions committed in other editing contexts, persistent
 	 * roots will be unloaded in the current one.
@@ -261,7 +263,7 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
  *
  * The returned set includes those that are pending insertion, undeletion or 
  * deletion, and deleted ones (explicitly loaded with -persistentRootForUUID: or 
- * when using COEditingContextUnloadingBehaviorNever).
+ * when using COEditingContextUnloadingBehaviorManual).
  */
 @property (nonatomic, readonly) NSSet *loadedPersistentRoots;
 
@@ -311,7 +313,7 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior) {
  * Same as -persistentRootForUUID: but doesn't cause loading.
  */
 - (COPersistentRoot *)loadedPersistentRootForUUID: (ETUUID *)aUUID;
-
+- (void)unloadPersistentRoot: (COPersistentRoot *)aPersistentRoot;
 /**
  * Returns a new persistent root that uses the given root object.
  *

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -535,6 +535,11 @@
 		postNotificationName: COEditingContextDidUnloadPersistentRootsNotification
 		              object: self
 		            userInfo: @{ kCOUnloadedPersistentRootsKey : S(aPersistentRoot) }];
+	
+	if ([aPersistentRoot isPersistentRootUncommitted])
+	{
+		[aPersistentRoot makeZombie];
+	}
 }
 
 - (void)unloadPersistentRoot: (COPersistentRoot *)aPersistentRoot

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -376,7 +376,7 @@
 		[_persistentRootsPendingDeletion removeObject: aPersistentRoot];
         [self unloadPersistentRoot: aPersistentRoot
 		                 isDeleted: YES
-		                    forces: NO];
+		                    force: NO];
     }
 }
 
@@ -511,7 +511,7 @@
 	}
 }
 
-- (void)unloadPersistentRoot: (COPersistentRoot *)aPersistentRoot isDeleted: (BOOL)deleted forces: (BOOL)forced
+- (void)unloadPersistentRoot: (COPersistentRoot *)aPersistentRoot isDeleted: (BOOL)deleted force: (BOOL)forced
 {
 	if (!forced && _unloadingBehavior == COEditingContextUnloadingBehaviorManual)
 		return;
@@ -539,7 +539,7 @@
 
 - (void)unloadPersistentRoot: (COPersistentRoot *)aPersistentRoot
 {
-	[self unloadPersistentRoot: aPersistentRoot isDeleted: aPersistentRoot.deleted forces: YES];
+	[self unloadPersistentRoot: aPersistentRoot isDeleted: aPersistentRoot.deleted force: YES];
 }
 
 #pragma mark Referencing Other Persistent Roots -
@@ -823,7 +823,7 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
 				
 				[self unloadPersistentRoot: persistentRoot
 				                 isDeleted: YES
-				                    forces: NO];
+				                    force: NO];
 			}
 			else if ([_persistentRootsPendingUndeletion containsObject: persistentRoot])
 			{

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -530,16 +530,16 @@
 	// of other objects holding references to the discarded object graphs. If we wait until
 	// -[COObjectGraphContext dealloc], COObject.deadRelationshipCache will be nil.
 	[[[aPersistentRoot allObjectGraphContexts] mappedCollection] discardAllObjects];
+		
+	if ([aPersistentRoot isPersistentRootUncommitted])
+	{
+		[aPersistentRoot makeZombie];
+	}
 	
 	[[NSNotificationCenter defaultCenter]
 		postNotificationName: COEditingContextDidUnloadPersistentRootsNotification
 		              object: self
 		            userInfo: @{ kCOUnloadedPersistentRootsKey : S(aPersistentRoot) }];
-	
-	if ([aPersistentRoot isPersistentRootUncommitted])
-	{
-		[aPersistentRoot makeZombie];
-	}
 }
 
 - (void)unloadPersistentRoot: (COPersistentRoot *)aPersistentRoot

--- a/Core/COObjectGraphContext+Private.h
+++ b/Core/COObjectGraphContext+Private.h
@@ -81,6 +81,10 @@
 /**
  * This method is only exposed to be used internally by CoreObject.
  */
+- (void) discardAllObjects;
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
 - (void)replaceObject: (COObject *)anObject withObject: (COObject *)aReplacement;
 /**
  * This method is only exposed to be used internally by CoreObject.

--- a/Core/COObjectGraphContext.m
+++ b/Core/COObjectGraphContext.m
@@ -139,7 +139,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 
 - (void)dealloc
 {
-	[self discardObjectsWithUUIDs:  [NSSet setWithArray: _loadedObjects.allKeys]];
+	[self discardAllObjects];
 }
 
 - (NSString *)description
@@ -691,7 +691,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 {
 	if ([self branch] == nil)
 	{
-		[self discardObjectsWithUUIDs: [NSSet setWithArray: [_loadedObjects allKeys]]];
+		[self discardAllObjects];
 		[self acceptAllChanges];
 		ETAssert([[self loadedObjects] isEmpty]);
 	}
@@ -699,6 +699,11 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
 	{
 		[[self branch] reloadAtRevision: [[self branch] currentRevision]];
 	}
+}
+
+- (void)discardAllObjects
+{
+	[self discardObjectsWithUUIDs:  [NSSet setWithArray: _loadedObjects.allKeys]];
 }
 
 /**

--- a/Core/COObjectGraphContext.m
+++ b/Core/COObjectGraphContext.m
@@ -847,7 +847,7 @@ NSString * const COObjectGraphContextEndBatchChangeNotification = @"COObjectGrap
  *
  * The referring objects are the inner objects that hold a reference to it.
  *
- * For -updateCrossPersistentRootReferencesToPersistentRoot:branch:isDeleted:,
+ * For -updateCrossPersistentRootReferencesToPersistentRoot:branch:isFault:,
  * this method is a bottleneck. To make it even faster, we could access ivars
  * directly and preallocate some COPath objects.
  */

--- a/Core/COPersistentRoot+Private.h
+++ b/Core/COPersistentRoot+Private.h
@@ -89,6 +89,11 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 - (void) sendChangeNotification;
 
+/**
+ * This property is only exposed to be used internally by CoreObject.
+ */
+@property (nonatomic, readonly) NSSet *allBranches;
+
 - (void)deleteBranch: (COBranch *)aBranch;
 - (void)undeleteBranch: (COBranch *)aBranch;
 

--- a/Core/COPersistentRoot+Private.h
+++ b/Core/COPersistentRoot+Private.h
@@ -96,5 +96,12 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 - (void)deleteBranch: (COBranch *)aBranch;
 - (void)undeleteBranch: (COBranch *)aBranch;
-
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
+- (void)assertNotZombie;
+/**
+ * This method is only exposed to be used internally by CoreObject.
+ */
+- (void)makeZombie;
 @end

--- a/Core/COPersistentRoot.h
+++ b/Core/COPersistentRoot.h
@@ -392,6 +392,12 @@ extern NSString * const COPersistentRootDidChangeNotification;
  * See also -hasChanges and -[COBranch discardAllChanges].
  */
 - (void)discardAllChanges;
+/**
+ * Returns whether the persistent root's editing context has relinquished
+ * control over this object. If YES, this instance can no longer be used
+ * and calling any methods may throw an exception
+ */
+@property (nonatomic, readonly) BOOL isZombie;
 
 
 /** @taskunit Convenience */

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -385,7 +385,7 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	}
 	[self.editingContext updateCrossPersistentRootReferencesToPersistentRoot: aBranch.persistentRoot
 	                                                                  branch: aBranch
-	                                                               isDeleted: YES];
+	                                                                 isFault: YES];
 }
 
 - (void)undeleteBranch: (COBranch *)aBranch
@@ -400,7 +400,7 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
     }
 	[self.editingContext updateCrossPersistentRootReferencesToPersistentRoot: aBranch.persistentRoot
 	                                                                  branch: aBranch
-	                                                               isDeleted: aBranch.persistentRoot.deleted];
+	                                                                 isFault: aBranch.persistentRoot.deleted];
 }
 
 #pragma mark Pending Changes -

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -172,6 +172,10 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 - (NSString *)description
 {
+	if ([self isZombie])
+	{
+		return @"<zombie persistent root>";
+	}
 	return [NSString stringWithFormat: @"<%@ %p - %@ - %@>",
 		NSStringFromClass([self class]), self, _UUID, [[[self rootObject] entityDescription] name]];
 }
@@ -487,6 +491,11 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	[_currentBranchObjectGraph discardAllChanges];
 	
 	ETAssert([self hasChanges] == NO);
+}
+
+- (BOOL) isZombie
+{
+	return (_parentContext == nil);
 }
 
 #pragma mark Convenience -

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -371,12 +371,9 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 - (void)deleteBranch: (COBranch *)aBranch
 {
-    if ([aBranch isBranchUncommitted])
-    {
-        [_branchForUUID removeObjectForKey: [aBranch UUID]];
-    }
-	else if ([_branchesPendingUndeletion containsObject: aBranch])
+	if ([_branchesPendingUndeletion containsObject: aBranch])
 	{
+		ETAssert(!aBranch.isBranchUncommitted);
 		[_branchesPendingUndeletion removeObject: aBranch];
 	}
 	else
@@ -386,12 +383,19 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	[self.editingContext updateCrossPersistentRootReferencesToPersistentRoot: aBranch.persistentRoot
 	                                                                  branch: aBranch
 	                                                                 isFault: YES];
+	
+    if (aBranch.isBranchUncommitted)
+    {
+		[_branchesPendingDeletion removeObject: aBranch];
+        [_branchForUUID removeObjectForKey: aBranch.UUID];
+    }
 }
 
 - (void)undeleteBranch: (COBranch *)aBranch
 {
     if ([_branchesPendingDeletion containsObject: aBranch])
     {
+		ETAssert(!aBranch.isBranchUncommitted);
         [_branchesPendingDeletion removeObject: aBranch];
     }
     else
@@ -401,6 +405,11 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	[self.editingContext updateCrossPersistentRootReferencesToPersistentRoot: aBranch.persistentRoot
 	                                                                  branch: aBranch
 	                                                                 isFault: aBranch.persistentRoot.deleted];
+
+    if (aBranch.isBranchUncommitted)
+    {
+		[_branchesPendingUndeletion removeObject: aBranch];
+	}
 }
 
 #pragma mark Pending Changes -

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -343,6 +343,11 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 	// TODO: Update cross persistent root references
 }
 
+- (NSSet *)allBranches
+{
+	return [NSSet setWithArray: _branchForUUID.allValues];
+}
+
 - (NSSet *)branches
 {
     return [NSSet setWithArray: [[_branchForUUID allValues] filteredCollectionWithBlock: ^(id obj)

--- a/Core/COPersistentRoot.m
+++ b/Core/COPersistentRoot.m
@@ -261,6 +261,12 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
 
 - (void)setDeleted: (BOOL)deleted
 {
+	[self assertNotZombie];
+	if (deleted == [self isDeleted])
+	{
+		return;
+	}
+	
     if (deleted)
     {
         [_parentContext deletePersistentRoot: self];
@@ -928,6 +934,21 @@ cheapCopyPersistentRootUUID: (ETUUID *)cheapCopyPersistentRootID
     [ctx setItemGraph: items];
 
     return ctx;
+}
+
+- (void)assertNotZombie
+{
+	if (self.isZombie)
+	{
+		[NSException raise: NSInternalInconsistencyException
+					format: @"Method called on zombie COPersistentRoot"];
+	}
+}
+
+- (void)makeZombie
+{
+	[self assertNotZombie];
+	_parentContext = nil;
 }
 
 @end

--- a/Tests/Core/TestEditingContext.m
+++ b/Tests/Core/TestEditingContext.m
@@ -47,24 +47,45 @@
 	UKDoesNotRaiseException([ctx insertNewPersistentRootWithEntityName: @"OutlineItem"]);
 }
 
-- (void)testDeleteUncommittedPersistentRoot
+- (void) validateNewPersistentRoot: (COPersistentRoot *)persistentRoot UUID: (ETUUID *)uuid
 {
-    COPersistentRoot *persistentRoot = [ctx insertNewPersistentRootWithEntityName: @"Anonymous.OutlineItem"];
-    ETUUID *uuid = [persistentRoot UUID];
-    
     UKTrue([ctx hasChanges]);
     UKObjectsEqual(S(persistentRoot), [ctx persistentRoots]);
     UKObjectsEqual([NSSet set], [ctx persistentRootsPendingDeletion]);
     UKNotNil([ctx persistentRootForUUID: uuid]);
     UKNil([store persistentRootInfoForUUID: uuid]);
     UKFalse([persistentRoot isDeleted]);
+}
+
+- (void)testDeleteUncommittedPersistentRoot
+{
+    COPersistentRoot *persistentRoot = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"];
+    ETUUID *uuid = [persistentRoot UUID];
+    
+	[self validateNewPersistentRoot: persistentRoot UUID: uuid];
     
     persistentRoot.deleted = YES;
     
     UKFalse([ctx hasChanges]);
-    UKObjectsEqual([NSSet set], [ctx persistentRoots]);
-    UKObjectsEqual([NSSet set], [ctx persistentRootsPendingDeletion]);
+    UKTrue([[ctx persistentRoots] isEmpty]);
+    UKTrue([[ctx persistentRootsPendingDeletion] isEmpty]);
     UKNil([ctx persistentRootForUUID: uuid]);
+    UKNil([store persistentRootInfoForUUID: uuid]);
+}
+
+- (void)testUndeleteUncommittedPersistentRoot
+{
+    COPersistentRoot *persistentRoot = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"];
+    ETUUID *uuid = [persistentRoot UUID];
+    
+	[self validateNewPersistentRoot: persistentRoot UUID: uuid];
+    
+    persistentRoot.deleted = NO;
+    
+    UKTrue([ctx hasChanges]);
+    UKObjectsEqual(S(persistentRoot), [ctx persistentRoots]);
+    UKTrue([[ctx persistentRootsPendingUndeletion] isEmpty]);
+    UKNotNil([ctx persistentRootForUUID: uuid]);
     UKNil([store persistentRootInfoForUUID: uuid]);
 }
 

--- a/Tests/Core/TestPersistentRoot.m
+++ b/Tests/Core/TestPersistentRoot.m
@@ -42,7 +42,7 @@
 	// To cope with this, the check block could cover more cases:
 	// - valid/loaded deleted persistent root reference
 	// - invalid/unloaded deleted persistent root reference
-	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorNever;
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
     persistentRoot =  [ctx insertNewPersistentRootWithEntityName: @"Anonymous.OutlineItem"];
 	rootObj = [persistentRoot rootObject];

--- a/Tests/Relationship/TestOrderedRelationship.m
+++ b/Tests/Relationship/TestOrderedRelationship.m
@@ -170,21 +170,24 @@
 {
 	SUPERINIT;
 	
-	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorNever;
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
-	group1 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupNoOpposite"].rootObject;
-	item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
-	item1.label = @"current";
-	item2 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
-	group1.contents = A(item1, item2);
-	group1.label = @"current";
-	[ctx commit];
+	// Ensure these objects are deallocated when unloading their persistent root
+	@autoreleasepool {
+		group1 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupNoOpposite"].rootObject;
+		item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+		item1.label = @"current";
+		item2 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+		group1.contents = A(item1, item2);
+		group1.label = @"current";
+		[ctx commit];
 
-	otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
-	otherItem1.label = @"other";
-	otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
-	otherGroup1.label = @"other";
-	[ctx commit];
+		otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+		otherItem1.label = @"other";
+		otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+		otherGroup1.label = @"other";
+		[ctx commit];
+	}
 
 	group1uuid = group1.persistentRoot.UUID;
 	item1uuid = item1.persistentRoot.UUID;
@@ -685,6 +688,66 @@
 
 	UKNil([[ctx2 deadRelationshipCache] referringObjectsForPath: item1Path]);
 	UKObjectsEqual(A(group1ctx2), [[[ctx2 deadRelationshipCache] referringObjectsForPath: item2Path] allObjects]);
+}
+
+- (void)testSourcePersistentRootUnloadingOnDeletion
+{
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorOnDeletion;
+
+	@autoreleasepool {
+		item1.persistentRoot.deleted = YES;
+		[ctx commit];
+		item1 = nil;
+	}
+
+	UKObjectsEqual(A([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+
+	@autoreleasepool {
+		group1.persistentRoot.deleted = YES;
+		[ctx commit];
+		group1 = nil;
+	}
+
+	UKTrue([item2.incomingRelationshipCache referringObjects].isEmpty);
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+
+	UKObjectsEqual(A([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+
+	// Force lazy loading of item1
+	NSArray *reloadedContents = group1.contents;
+	item1 = [ctx persistentRootForUUID: item1uuid].rootObject;
+
+	UKObjectsEqual(A(item2), reloadedContents);
+	UKObjectsEqual(S(group1), [item2.incomingRelationshipCache referringObjects]);
+}
+
+- (void)testSourcePersistentRootManualUnloading
+{
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: item1.persistentRoot];
+		item1 = nil;
+	}
+
+	UKObjectsEqual(A([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+	
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: group1.persistentRoot];
+		group1 = nil;
+	}
+	
+	UKTrue([item2.incomingRelationshipCache referringObjects].isEmpty);
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+	// Force lazy loading of item1
+	NSArray *reloadedContents = group1.contents;
+	item1 = [ctx persistentRootForUUID: item1uuid].rootObject;
+
+	UKObjectsEqual(A(item1, item2), reloadedContents);
+	UKObjectsEqual(S(group1), [item2.incomingRelationshipCache referringObjects]);
 }
 
 @end

--- a/Tests/Relationship/TestOrderedRelationshipWithOpposite.m
+++ b/Tests/Relationship/TestOrderedRelationshipWithOpposite.m
@@ -132,7 +132,7 @@
 {
 	SUPERINIT;
 	
-	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorNever;
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
 	group1 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupWithOpposite"].rootObject;
 	item1 = [ctx insertNewPersistentRootWithEntityName: @"OrderedGroupContent"].rootObject;

--- a/Tests/Relationship/TestUnivaluedRelationship.m
+++ b/Tests/Relationship/TestUnivaluedRelationship.m
@@ -145,7 +145,7 @@
 {
 	SUPERINIT;
 	
-	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorNever;
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
 	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupNoOpposite"].rootObject;
 	item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;

--- a/Tests/Relationship/TestUnivaluedRelationship.m
+++ b/Tests/Relationship/TestUnivaluedRelationship.m
@@ -147,19 +147,21 @@
 	
 	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
-	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupNoOpposite"].rootObject;
-	item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
-	item1.label = @"current";
-	group1.label = @"current";
-	group1.content = item1;
-	[ctx commit];
+	@autoreleasepool {
+		group1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupNoOpposite"].rootObject;
+		item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+		item1.label = @"current";
+		group1.label = @"current";
+		group1.content = item1;
+		[ctx commit];
 
-	otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
-	otherItem1.label = @"other";
-	otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
-	otherGroup1.label = @"other";
-	[ctx commit];
-	
+		otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+		otherItem1.label = @"other";
+		otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+		otherGroup1.label = @"other";
+		[ctx commit];
+	}
+
 	group1uuid = group1.persistentRoot.UUID;
 	item1uuid = item1.persistentRoot.UUID;
 
@@ -661,6 +663,53 @@
 	COPath *item1Path = [COPath pathWithPersistentRoot: item1uuid];
 
 	UKNil([[ctx2 deadRelationshipCache] referringObjectsForPath: item1Path]);
+}
+
+- (void)testSourcePersistentRootUnloadingOnDeletion
+{
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorOnDeletion;
+
+	@autoreleasepool {
+		item1.persistentRoot.deleted = YES;
+		[ctx commit];
+		item1 = nil;
+	}
+
+	UKObjectsEqual([COPath pathWithPersistentRoot: item1uuid], [group1 serializableValueForStorageKey: @"content"]);
+
+	@autoreleasepool {
+		group1.persistentRoot.deleted = YES;
+		[ctx commit];
+		group1 = nil;
+	}
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+
+	UKObjectsEqual([COPath pathWithPersistentRoot: item1uuid], [group1 serializableValueForStorageKey: @"content"]);
+	UKNil(group1.content);
+}
+
+- (void)testSourcePersistentRootManualUnloading
+{
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: item1.persistentRoot];
+		item1 = nil;
+	}
+
+	UKObjectsEqual([COPath pathWithPersistentRoot: item1uuid], [group1 serializableValueForStorageKey: @"content"]);
+	
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: group1.persistentRoot];
+		group1 = nil;
+	}
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+	// Force lazy loading of item1
+	COObject *reloadedContent = group1.content;
+	item1 = [ctx persistentRootForUUID: item1uuid].rootObject;
+
+	UKObjectsEqual(item1, reloadedContent);
+	UKObjectsEqual(S(group1), [item1.incomingRelationshipCache referringObjects]);
 }
 
 @end

--- a/Tests/Relationship/TestUnivaluedRelationshipWithOpposite.m
+++ b/Tests/Relationship/TestUnivaluedRelationshipWithOpposite.m
@@ -105,7 +105,7 @@
 {
 	SUPERINIT;
 	
-	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorNever;
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
 	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupWithOpposite"].rootObject;
 	item1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupContent"].rootObject;

--- a/Tests/Relationship/TestUnivaluedRelationshipWithOpposite.m
+++ b/Tests/Relationship/TestUnivaluedRelationshipWithOpposite.m
@@ -107,18 +107,20 @@
 	
 	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
-	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupWithOpposite"].rootObject;
-	item1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupContent"].rootObject;
-	item1.label = @"current";
-	group1.label = @"current";
-	group1.content = item1;
-	[ctx commit];
+	@autoreleasepool {
+		group1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupWithOpposite"].rootObject;
+		item1 = [ctx insertNewPersistentRootWithEntityName: @"UnivaluedGroupContent"].rootObject;
+		item1.label = @"current";
+		group1.label = @"current";
+		group1.content = item1;
+		[ctx commit];
 
-	otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
-	otherItem1.label = @"other";
-	otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
-	otherGroup1.label = @"other";
-	[ctx commit];
+		otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+		otherItem1.label = @"other";
+		otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+		otherGroup1.label = @"other";
+		[ctx commit];
+	}
 
 	group1uuid = group1.persistentRoot.UUID;
 	item1uuid = item1.persistentRoot.UUID;
@@ -549,5 +551,51 @@
 	UKNil([[ctx2 deadRelationshipCache] referringObjectsForPath: item1Path]);
 }
 
+- (void)testSourcePersistentRootUnloadingOnDeletion
+{
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorOnDeletion;
+
+	@autoreleasepool {
+		item1.persistentRoot.deleted = YES;
+		[ctx commit];
+		item1 = nil;
+	}
+
+	UKObjectsEqual([COPath pathWithPersistentRoot: item1uuid], [group1 serializableValueForStorageKey: @"content"]);
+
+	@autoreleasepool {
+		group1.persistentRoot.deleted = YES;
+		[ctx commit];
+		group1 = nil;
+	}
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+
+	UKObjectsEqual([COPath pathWithPersistentRoot: item1uuid], [group1 serializableValueForStorageKey: @"content"]);
+	UKNil(group1.content);
+}
+
+- (void)testSourcePersistentRootManualUnloading
+{
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: item1.persistentRoot];
+		item1 = nil;
+	}
+
+	UKObjectsEqual([COPath pathWithPersistentRoot: item1uuid], [group1 serializableValueForStorageKey: @"content"]);
+	
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: group1.persistentRoot];
+		group1 = nil;
+	}
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+	// Force lazy loading of item1
+	UnivaluedGroupContent *reloadedContent = group1.content;
+	item1 = [ctx persistentRootForUUID: item1uuid].rootObject;
+
+	UKObjectsEqual(item1, reloadedContent);
+	UKObjectsEqual(S(group1), item1.parents);
+}
 
 @end

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -152,19 +152,21 @@
 	
 	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
-	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnorderedGroupNoOpposite"].rootObject;
-	item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
-	item1.label = @"current";
-	item2 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
-	group1.label = @"current";
-	group1.contents = S(item1, item2);
-	[ctx commit];
+	@autoreleasepool {
+		group1 = [ctx insertNewPersistentRootWithEntityName: @"UnorderedGroupNoOpposite"].rootObject;
+		item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+		item1.label = @"current";
+		item2 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
+		group1.label = @"current";
+		group1.contents = S(item1, item2);
+		[ctx commit];
 
-	otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
-	otherItem1.label = @"other";
-	otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
-	otherGroup1.label = @"other";
-	[ctx commit];
+		otherItem1 = [item1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+		otherItem1.label = @"other";
+		otherGroup1 = [group1.persistentRoot.currentBranch makeBranchWithLabel: @"other"].rootObject;
+		otherGroup1.label = @"other";
+		[ctx commit];
+	}
 
 	group1uuid = group1.persistentRoot.UUID;
 	item1uuid = item1.persistentRoot.UUID;
@@ -633,6 +635,66 @@
 	
 	UKNil([[ctx2 deadRelationshipCache] referringObjectsForPath: item1Path]);
 	UKObjectsEqual(A(group1ctx2), [[[ctx2 deadRelationshipCache] referringObjectsForPath: item2Path] allObjects]);
+}
+
+- (void)testSourcePersistentRootUnloadingOnDeletion
+{
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorOnDeletion;
+
+	@autoreleasepool {
+		item1.persistentRoot.deleted = YES;
+		[ctx commit];
+		item1 = nil;
+	}
+
+	UKObjectsEqual(S([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+
+	@autoreleasepool {
+		group1.persistentRoot.deleted = YES;
+		[ctx commit];
+		group1 = nil;
+	}
+
+	UKTrue([item2.incomingRelationshipCache referringObjects].isEmpty);
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+
+	UKObjectsEqual(S([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+
+	// Force lazy loading of item1
+	NSSet *reloadedContents = group1.contents;
+	item1 = [ctx persistentRootForUUID: item1uuid].rootObject;
+
+	UKObjectsEqual(S(item2), reloadedContents);
+	UKObjectsEqual(S(group1), [item2.incomingRelationshipCache referringObjects]);
+}
+
+- (void)testSourcePersistentRootManualUnloading
+{
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: item1.persistentRoot];
+		item1 = nil;
+	}
+
+	UKObjectsEqual(S([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+	
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: group1.persistentRoot];
+		group1 = nil;
+	}
+	
+	UKTrue([item2.incomingRelationshipCache referringObjects].isEmpty);
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+	// Force lazy loading of item1
+	NSSet *reloadedContents = group1.contents;
+	item1 = [ctx persistentRootForUUID: item1uuid].rootObject;
+
+	UKObjectsEqual(S(item1, item2), reloadedContents);
+	UKObjectsEqual(S(group1), [item2.incomingRelationshipCache referringObjects]);
 }
 
 @end

--- a/Tests/Relationship/TestUnorderedRelationship.m
+++ b/Tests/Relationship/TestUnorderedRelationship.m
@@ -150,7 +150,7 @@
 {
 	SUPERINIT;
 	
-	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorNever;
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
 	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnorderedGroupNoOpposite"].rootObject;
 	item1 = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;

--- a/Tests/Relationship/TestUnorderedRelationshipWithOpposite.m
+++ b/Tests/Relationship/TestUnorderedRelationshipWithOpposite.m
@@ -113,7 +113,7 @@
 {
 	SUPERINIT;
 	
-	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorNever;
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
 	group1 = [ctx insertNewPersistentRootWithEntityName: @"UnorderedGroupWithOpposite"].rootObject;
 	item1 = [ctx insertNewPersistentRootWithEntityName: @"UnorderedGroupContent"].rootObject;

--- a/Tests/Relationship/TestUnorderedRelationshipWithOpposite.m
+++ b/Tests/Relationship/TestUnorderedRelationshipWithOpposite.m
@@ -584,4 +584,65 @@
 	UKObjectsEqual(A(group1ctx2), [[[ctx2 deadRelationshipCache] referringObjectsForPath: item2Path] allObjects]);
 }
 
+- (void)testSourcePersistentRootUnloadingOnDeletion
+{
+	ctx.unloadingBehavior = COEditingContextUnloadingBehaviorOnDeletion;
+
+	@autoreleasepool {
+		item1.persistentRoot.deleted = YES;
+		[ctx commit];
+		item1 = nil;
+	}
+
+	UKObjectsEqual(S([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+
+	@autoreleasepool {
+		group1.persistentRoot.deleted = YES;
+		[ctx commit];
+		group1 = nil;
+	}
+
+	UKTrue(item2.parentGroups.isEmpty);
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+
+	UKObjectsEqual(S([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+
+	// Force lazy loading of item1
+	NSSet *reloadedContents = group1.contents;
+	item1 = [ctx persistentRootForUUID: item1uuid].rootObject;
+
+	UKObjectsEqual(S(item2), reloadedContents);
+	// group1 is deleted so it's hidden by the incoming relationship cache
+	UKTrue(item2.parentGroups.isEmpty);
+}
+
+- (void)testSourcePersistentRootManualUnloading
+{
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: item1.persistentRoot];
+		item1 = nil;
+	}
+
+	UKObjectsEqual(S([COPath pathWithPersistentRoot: item1uuid], item2),
+	               [[group1 serializableValueForStorageKey: @"contents"] allReferences]);
+	
+	@autoreleasepool {
+		[ctx unloadPersistentRoot: group1.persistentRoot];
+		group1 = nil;
+	}
+	
+	UKTrue(item2.parentGroups.isEmpty);
+
+	group1 = [ctx persistentRootForUUID: group1uuid].rootObject;
+	// Force lazy loading of item1
+	NSSet *reloadedContents = group1.contents;
+	item1 = [ctx persistentRootForUUID: item1uuid].rootObject;
+
+	UKObjectsEqual(S(item1, item2), reloadedContents);
+	UKObjectsEqual(S(group1), item2.parentGroups);
+}
+
 @end


### PR DESCRIPTION
I finished to implement the unloading support, this was quite straightforward to implement.

-[COEditingContext unloadPersistentRoot:] should probably be changed to take a set of persistent roots. This would match the unload notification that reports a set of unloaded persistent roots. What do you think?

For -updateCrossPersistentRootReferences in COEditingContext, it could be better to rename `faulting`as `dead`and `isTargetFaulting`as `isTargetDead` to get a more uniform terminology, since we already have variables mentionning dead vs live refs in this method. isTargetFaulting sounds also a bit weird to my ears.

Let me know if you have any questions or comments.