### PR TITLE
Item subscripting

### DIFF
--- a/Benchmark/TestSQLiteStorePerformance.m
+++ b/Benchmark/TestSQLiteStorePerformance.m
@@ -231,8 +231,7 @@ static int itemChangedAtCommit(int i)
 
         NSString *expectedLabel = [self labelForCommit: rev child: i];
 
-        UKObjectsEqual(expectedLabel,
-                       [item valueForAttribute: @"name"]);
+        UKObjectsEqual(expectedLabel, item[@"name"]);
 
         // Step back one revision
 

--- a/Extras/Diff/COAttributedStringDiff.m
+++ b/Extras/Diff/COAttributedStringDiff.m
@@ -538,7 +538,7 @@ static NSString *
 COHTMLCodesForAttributesItemGraph(COItemGraph *graph)
 {
     NSString *htmlCodes = [[graph.items mappedCollectionWithBlock:
-        ^(id obj) { return [obj valueForAttribute: @"htmlCode"]; }] componentsJoinedByString: @","];
+        ^(id obj) { return obj[@"htmlCode"]; }] componentsJoinedByString: @","];
     return htmlCodes;
 }
 

--- a/Extras/Model/COAttributedString.m
+++ b/Extras/Model/COAttributedString.m
@@ -103,12 +103,12 @@
     // Trim off excess characters
 
     COMutableItem *firstChunk = [result itemForUUID: copiedUUIDs[0]];
-    [firstChunk setValue: [[firstChunk valueForAttribute: @"text"] substringFromIndex: excessAtStart]
+    [firstChunk setValue: [firstChunk[@"text"] substringFromIndex: excessAtStart]
             forAttribute: @"text"
                     type: kCOTypeString];
 
     COMutableItem *lastChunk = [result itemForUUID: copiedUUIDs.lastObject];
-    [lastChunk setValue: [[lastChunk valueForAttribute: @"text"] substringToIndex: ([[lastChunk valueForAttribute: @"text"] length] - excessAtEnd)]
+    [lastChunk setValue: [lastChunk[@"text"] substringToIndex: ([lastChunk[@"text"] length] - excessAtEnd)]
            forAttribute: @"text"
                    type: kCOTypeString];
 

--- a/Tests/Core/TestCopierWithIsShared.m
+++ b/Tests/Core/TestCopierWithIsShared.m
@@ -119,13 +119,13 @@ static NSArray *initialUUIDs;
     // Check structure ("copy semantics.pdf" page 9)
 
     COItem *drawingCopyItem = [initialGraph itemForUUID: drawing2];
-    COItem *group1CopyItem = [initialGraph itemForUUID: [drawingCopyItem valueForAttribute: @"contents"][0]];
-    COItem *group2CopyItem = [initialGraph itemForUUID: [drawingCopyItem valueForAttribute: @"contents"][1]];
-    COItem *shape1CopyItem = [initialGraph itemForUUID: [group1CopyItem valueForAttribute: @"contents"][0]];
-    COItem *shape2CopyItem = [initialGraph itemForUUID: [group1CopyItem valueForAttribute: @"contents"][1]];
-    COItem *shape3CopyItem = [initialGraph itemForUUID: [group2CopyItem valueForAttribute: @"contents"][0]];
-    COItem *shape4CopyItem = [initialGraph itemForUUID: [group2CopyItem valueForAttribute: @"contents"][1]];
-    COItem *style2CopyItem = [initialGraph itemForUUID: [shape3CopyItem valueForAttribute: @"refs"][0]];
+    COItem *group1CopyItem = [initialGraph itemForUUID: drawingCopyItem[@"contents"][0]];
+    COItem *group2CopyItem = [initialGraph itemForUUID: drawingCopyItem[@"contents"][1]];
+    COItem *shape1CopyItem = [initialGraph itemForUUID: group1CopyItem[@"contents"][0]];
+    COItem *shape2CopyItem = [initialGraph itemForUUID: group1CopyItem[@"contents"][1]];
+    COItem *shape3CopyItem = [initialGraph itemForUUID: group2CopyItem[@"contents"][0]];
+    COItem *shape4CopyItem = [initialGraph itemForUUID: group2CopyItem[@"contents"][1]];
+    COItem *style2CopyItem = [initialGraph itemForUUID: shape3CopyItem[@"refs"][0]];
 
     UKNotNil(drawingCopyItem);
     UKFalse([initialUUIDs containsObject: drawingCopyItem.UUID]);
@@ -149,17 +149,17 @@ static NSArray *initialUUIDs;
     UKFalse([initialUUIDs containsObject: shape4CopyItem.UUID]);
 
     // Check that the copies of shape1 and shape2 have aliases to the original style1 and style2
-    UKObjectsEqual(style1, [shape1CopyItem valueForAttribute: @"refs"][0]);
-    UKObjectsEqual(style1, [shape2CopyItem valueForAttribute: @"refs"][0]);
+    UKObjectsEqual(style1, shape1CopyItem[@"refs"][0]);
+    UKObjectsEqual(style1, shape2CopyItem[@"refs"][0]);
 
     // The copy of shape3 has a reference to a copy of style2
 
     UKNotNil(style2CopyItem);
     UKFalse([initialUUIDs containsObject: style2CopyItem.UUID]);
-    UKObjectsEqual(@"style2", [style2CopyItem valueForAttribute: @"name"]);
+    UKObjectsEqual(@"style2", style2CopyItem[@"name"]);
 
     // The copy of shape4 should refer to the copy of shape3, not the original
-    UKObjectsEqual(shape3CopyItem.UUID, [shape4CopyItem valueForAttribute: @"refs"][0]);
+    UKObjectsEqual(shape3CopyItem.UUID, shape4CopyItem[@"refs"][0]);
 }
 
 - (void)testCOObjectCopyWithIsSharedUnset

--- a/Tests/Core/TestCopierWithIsSharedFalseAndMultipleReferences.m
+++ b/Tests/Core/TestCopierWithIsSharedFalseAndMultipleReferences.m
@@ -85,11 +85,11 @@ static NSArray *initialUUIDs;
     // Check structure ("copy semantics.pdf" page 10)
 
     COItem *drawingCopyItem = [initialGraph itemForUUID: drawing2];
-    COItem *shape2CopyItem = [initialGraph itemForUUID: [drawingCopyItem valueForAttribute: @"contents"][1]];
-    COItem *shape3CopyItem = [initialGraph itemForUUID: [drawingCopyItem valueForAttribute: @"contents"][0]];
+    COItem *shape2CopyItem = [initialGraph itemForUUID: drawingCopyItem[@"contents"][1]];
+    COItem *shape3CopyItem = [initialGraph itemForUUID: drawingCopyItem[@"contents"][0]];
 
-    COItem *style2CopyItemA = [initialGraph itemForUUID: [shape2CopyItem valueForAttribute: @"refs"][0]];
-    COItem *style2CopyItemB = [initialGraph itemForUUID: [shape3CopyItem valueForAttribute: @"refs"][0]];
+    COItem *style2CopyItemA = [initialGraph itemForUUID: shape2CopyItem[@"refs"][0]];
+    COItem *style2CopyItemB = [initialGraph itemForUUID: shape3CopyItem[@"refs"][0]];
 
     UKNotNil(drawingCopyItem);
     UKFalse([initialUUIDs containsObject: drawingCopyItem.UUID]);
@@ -103,7 +103,7 @@ static NSArray *initialUUIDs;
     UKObjectsSame(style2CopyItemA, style2CopyItemB);
     UKNotNil(style2CopyItemA);
     UKFalse([initialUUIDs containsObject: style2CopyItemA.UUID]);
-    UKObjectsEqual(@"style2", [style2CopyItemA valueForAttribute: @"name"]);
+    UKObjectsEqual(@"style2", style2CopyItemA[@"name"]);
 }
 
 @end

--- a/Tests/Core/TestObjectGraphContext.m
+++ b/Tests/Core/TestObjectGraphContext.m
@@ -148,7 +148,7 @@
 
     [root1 setValue: @"another label" forProperty: kCOLabel];
 
-    UKObjectsEqual(@"root1", [root1Item valueForAttribute: kCOLabel]);
+    UKObjectsEqual(@"root1", root1Item[kCOLabel]);
     UKObjectsEqual(@"another label", [root1 valueForKey: kCOLabel]);
 
     // Check that we can't change the COItem
@@ -213,7 +213,7 @@
 
     // Ensure the change did not affect object in ctx1
 
-    UKObjectsEqual(@"hello", [mutableItem valueForAttribute: kCOLabel]);
+    UKObjectsEqual(@"hello", mutableItem[kCOLabel]);
     UKNil([object valueForKey: kCOLabel]);
 }
 
@@ -711,7 +711,7 @@ doesNotPostNotification: COObjectGraphContextObjectsDidChangeNotification];
 
     // TODO: Perhaps attempting to serialize this should throw an exception?
     COItem *item = root1.storeItem;
-    NSArray *itemContentsArray = [item valueForAttribute: @"contents"];
+    NSArray *itemContentsArray = item[@"contents"];
     UKIntsEqual(1, itemContentsArray.count);
     UKObjectsEqual([NSNull null], itemContentsArray[0]);
 }
@@ -802,7 +802,7 @@ doesNotPostNotification: COObjectGraphContextObjectsDidChangeNotification];
 
     // It should serialize to COBrokenPath
     COItem *item = root1.storeItem;
-    NSArray *itemContentsArray = [item valueForAttribute: @"contents"];
+    NSArray *itemContentsArray = item[@"contents"];
     UKIntsEqual(1, itemContentsArray.count);
     UKTrue([itemContentsArray[0] isBroken]);
 }

--- a/Tests/StorageDataModel/TestItem.m
+++ b/Tests/StorageDataModel/TestItem.m
@@ -256,21 +256,21 @@
                                               forAttribute: @"bar"
                                                       type: kCOTypeString]);
 
-    UKRaisesException([[immutable valueForAttribute: @"key1"] addObject: @"b"]);
-    UKRaisesException([[immutable valueForAttribute: @"key2"] addObject: @"B"]);
+    UKRaisesException([immutable[@"key1"] addObject: @"b"]);
+    UKRaisesException([immutable[@"key2"] addObject: @"B"]);
 
     COMutableItem *mutable = [immutable mutableCopy];
 
-    UKDoesNotRaiseException([[mutable valueForAttribute: @"key1"] addObject: @"b"]);
-    UKDoesNotRaiseException([[mutable valueForAttribute: @"key2"] addObject: @"B"]);
+    UKDoesNotRaiseException([mutable[@"key1"] addObject: @"b"]);
+    UKDoesNotRaiseException([mutable[@"key2"] addObject: @"B"]);
 
-    UKIntsEqual(1, [[immutable valueForAttribute: @"key1"] count]);
-    UKIntsEqual(1, [[immutable valueForAttribute: @"key2"] count]);
+    UKIntsEqual(1, [immutable[@"key1"] count]);
+    UKIntsEqual(1, [immutable[@"key2"] count]);
 
-    UKIntsEqual(2, [[mutable valueForAttribute: @"key1"] count]);
-    UKIntsEqual(2, [[mutable valueForAttribute: @"key2"] count]);
+    UKIntsEqual(2, [mutable[@"key1"] count]);
+    UKIntsEqual(2, [mutable[@"key2"] count]);
 
-    UKRaisesException([[mutable valueForAttribute: @"name"] appendString: @"xxx"]);
+    UKRaisesException([mutable[@"name"] appendString: @"xxx"]);
 }
 
 - (void)testEquality

--- a/Tests/StorageDataModel/TestItemStableSerialization.m
+++ b/Tests/StorageDataModel/TestItemStableSerialization.m
@@ -240,8 +240,8 @@ static COPath *Path(unsigned char num)
 
     for (NSString *key in asc.attributeNames)
     {
-        id ascValue = [asc valueForAttribute: key];
-        id dscValue = [dsc valueForAttribute: key];
+        id ascValue = asc[key];
+        id dscValue = dsc[key];
 
         UKObjectKindOf(ascValue, NSSet);
         UKObjectKindOf(dscValue, NSSet);


### PR DESCRIPTION
I played a bit with adding subscripting support to COItem. Since the result doesn't look as good as I expected, I didn't continue my work in master, but created a PR.

Not sure it's worth to keep subscripting support for COItem, since it only help a bit in the tests… elsewhere keeping -valueForAttribute: often looks better since we use -typeForAttribute: at the same time. Also updating an attribute with subscripting is not a possibility, since we always call -setValue:forAttribute:ofType: and never just -setValue:forAttribute:.

I added subscripting support with 9dffe9f357189280fe24219074a5f4ba4aa7a3ce

I don't really care about keeping it or discarding. I might be leaning a bit towards ditching it. What's your take on this?