### PR TITLE
Upgrade to project to Xcode 14.2 and fix warnings

### DIFF
--- a/Core/COObject+Private.h
+++ b/Core/COObject+Private.h
@@ -19,7 +19,7 @@ BOOL IsSetter(const char *selname, size_t sellen);
 BOOL isSerializablePrimitiveValue(id value);
 BOOL isSerializableScalarValue(id value);
 
-ETEntityDescription *entityDescriptionForObjectInRepository();
+ETEntityDescription *entityDescriptionForObjectInRepository(id anObject, ETModelDescriptionRepository *repo);
 
 @interface COObject ()
 

--- a/Core/COObject.m
+++ b/Core/COObject.m
@@ -777,7 +777,7 @@ static NSNull *cachedNSNull = nil;
 {
     ETPropertyDescription *propertyDesc = [_entityDescription propertyDescriptionForName: key];
     ETPropertyDescription *opposite = propertyDesc.opposite;
-    ETValidationResult *oppositeResult = nil;
+    __unused ETValidationResult *oppositeResult = nil;
 
     if (opposite != nil)
     {

--- a/CoreObject.xcodeproj/project.pbxproj
+++ b/CoreObject.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2959,7 +2959,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = "";
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = "Étoilé";
 				TargetAttributes = {
 					60E08C6119792BEA00D1B7AD = {
@@ -2972,13 +2972,9 @@
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "CoreObject" */;
 			compatibilityVersion = "Xcode 9.3";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
 				Base,
 				fr,
 				en,
@@ -3186,6 +3182,7 @@
 		};
 		6679B8FF185305E900971C2A /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -3195,10 +3192,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Derived from: https://github.com/gh-unit/gh-unit/blob/master/Scripts/RunTests.sh\n\n# If we aren't running from the command line, then exit\nif [ \"$TESTCOREOBJECT_AUTORUN\" = \"\" ]; then\nexit 0\nfi\n\nexport DYLD_FRAMEWORK_PATH=\"$CONFIGURATION_BUILD_DIR\"\n$TARGET_BUILD_DIR/$EXECUTABLE_PATH\nRETVAL=$?\n\nexit $RETVAL";
+			shellScript = "# Derived from: https://github.com/gh-unit/gh-unit/blob/master/Scripts/RunTests.sh\n\n# If we aren't running from the command line, then exit\nif [ \"$TESTCOREOBJECT_AUTORUN\" = \"\" ]; then\nexit 0\nfi\n\nexport DYLD_FRAMEWORK_PATH=\"$CONFIGURATION_BUILD_DIR\"\n$TARGET_BUILD_DIR/$EXECUTABLE_PATH\nRETVAL=$?\n\nexit $RETVAL\n";
 		};
 		66FD34871830B1D900898381 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -3208,7 +3206,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = XcodeCoverage/exportenv.sh;
+			shellScript = "XcodeCoverage/exportenv.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -3860,6 +3858,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -3896,6 +3895,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -3937,6 +3937,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -3973,6 +3974,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -3994,6 +3996,9 @@
 		60C913BF165BBED100E0C5F4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEAD_CODE_STRIPPING = YES;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -4001,6 +4006,9 @@
 		60C913C0165BBED100E0C5F4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEAD_CODE_STRIPPING = YES;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -4011,7 +4019,6 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = NO;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 6;
 				ENABLE_BITCODE = NO;
@@ -4029,6 +4036,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = (
 					"-DSQLITE_ENABLE_FTS3",
 					"-DSQLITE_ENABLTE_ENABLE_FTS3_PARENTHESIS",
@@ -4060,7 +4068,6 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = NO;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 6;
 				ENABLE_BITCODE = NO;
@@ -4072,6 +4079,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = (
 					"-DSQLITE_ENABLE_FTS3",
 					"-DSQLITE_ENABLTE_ENABLE_FTS3_PARENTHESIS",
@@ -4121,6 +4129,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -4157,6 +4166,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -4178,6 +4188,9 @@
 		66550BF417D51C8800327657 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEAD_CODE_STRIPPING = YES;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -4185,6 +4198,9 @@
 		66550BF517D51C8800327657 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEAD_CODE_STRIPPING = YES;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -4193,12 +4209,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 5;
 				FRAMEWORK_VERSION = A;
 				GCC_PREPROCESSOR_DEFINITIONS = "SANDBOXED=1";
 				INFOPLIST_FILE = CoreObjectInfo.plist;
 				INSTALL_PATH = "@rpath";
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = (
 					"-DSQLITE_ENABLE_FTS3",
 					"-DSQLITE_ENABLTE_ENABLE_FTS3_PARENTHESIS",
@@ -4219,12 +4237,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DYLIB_COMPATIBILITY_VERSION = 0;
 				DYLIB_CURRENT_VERSION = 5;
 				FRAMEWORK_VERSION = A;
 				GCC_PREPROCESSOR_DEFINITIONS = "SANDBOXED=1";
 				INFOPLIST_FILE = CoreObjectInfo.plist;
 				INSTALL_PATH = "@rpath";
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = (
 					"-DSQLITE_ENABLE_FTS3",
 					"-DSQLITE_ENABLTE_ENABLE_FTS3_PARENTHESIS",
@@ -4244,7 +4264,10 @@
 		791B4E2F1299C79300CCF472 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEAD_CODE_STRIPPING = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				PRODUCT_NAME = Test;
 				WARNING_CFLAGS = (
 					"-Wall",
@@ -4257,7 +4280,10 @@
 		791B4E301299C79300CCF472 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEAD_CODE_STRIPPING = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				PRODUCT_NAME = Test;
 				WARNING_CFLAGS = (
 					"-Wall",
@@ -4271,25 +4297,46 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-DDEBUG";
 				SDKROOT = macosx;
@@ -4305,20 +4352,41 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				SDKROOT = macosx;
 				WARNING_CFLAGS = (
 					"-Wall",

--- a/CoreObject.xcodeproj/xcshareddata/xcschemes/BenchmarkCoreObject.xcscheme
+++ b/CoreObject.xcodeproj/xcshareddata/xcschemes/BenchmarkCoreObject.xcscheme
@@ -27,6 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/Extras/ValueTransformers/COObjectToArchivedData.m
+++ b/Extras/ValueTransformers/COObjectToArchivedData.m
@@ -21,14 +21,18 @@
 
 - (id)transformedValue: (id)value
 {
-    return (value != nil ? [NSKeyedArchiver archivedDataWithRootObject: value] : nil);
+    return (value != nil ? [NSKeyedArchiver archivedDataWithRootObject: value
+                                                 requiringSecureCoding: NO
+                                                                 error: NULL] : nil);
 }
 
 - (id)reverseTransformedValue: (id)value
 {
     NSParameterAssert(value == nil || [value isKindOfClass: [NSData class]]);
 
-    return (value != nil ? [NSKeyedUnarchiver unarchiveObjectWithData: value] : nil);
+    return (value != nil ? [NSKeyedUnarchiver unarchivedObjectOfClass: [NSData class]
+                                                             fromData: value
+                                                                error: NULL] : nil);
 }
 
 @end

--- a/Store/COSQLiteStore+Private.h
+++ b/Store/COSQLiteStore+Private.h
@@ -27,6 +27,6 @@
                             branchUUID: (ETUUID *)branch;
 - (COSQLiteStorePersistentRootBackingStore *)backingStoreForPersistentRootUUID: (ETUUID *)aUUID
                                                             createIfNotPresent: (BOOL)createIfNotPresent;
-- (void)testingRunBlockInStoreQueue: (void (^)())aBlock;
+- (void)testingRunBlockInStoreQueue: (void (^)(void))aBlock;
 
 @end

--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -1205,7 +1205,7 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
     return result;
 }
 
-- (void)testingRunBlockInStoreQueue: (void (^)())aBlock
+- (void)testingRunBlockInStoreQueue: (void (^)(void))aBlock
 {
     dispatch_sync(queue_, aBlock);
 }

--- a/Tests/Core/TestRevisionNumber.m
+++ b/Tests/Core/TestRevisionNumber.m
@@ -60,7 +60,7 @@
     //  1--2--3
     //      \
     //       4
-    ETUUID *objectUUID;
+    __unused ETUUID *objectUUID;
 
     COPersistentRoot *persistentRoot = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"];
 

--- a/Tests/Extras/Model/TestAttributedStringCommon.h
+++ b/Tests/Extras/Model/TestAttributedStringCommon.h
@@ -1,7 +1,7 @@
 #import "TestCommon.h"
 
-ETUUID *AttributedString1UUID();
-ETUUID *AttributedString2UUID();
+ETUUID *AttributedString1UUID(void);
+ETUUID *AttributedString2UUID(void);
 
 @interface EditingContextTestCase (TestAttributedStringCommon)
 

--- a/Tests/Extras/Model/TestAttributedStringWrapper.m
+++ b/Tests/Extras/Model/TestAttributedStringWrapper.m
@@ -124,8 +124,15 @@ changeInLength: (NSInteger)delta
 
 
 @implementation AbstractTextStorageTests
-
+#ifdef GNUSTEP
 - (void)textStorageWillProcessEditing: (NSNotification *)notification
+
+#else
+- (void)textStorage: (NSTextStorage *)textStorage
+ willProcessEditing: (NSTextStorageEditActions)editedMask
+              range: (NSRange)editedRange
+     changeInLength: (NSInteger)changeInLength
+#endif
 {
     _didProcessEditing = YES;
     _lastEditedRange = as.editedRange;

--- a/Tests/Model/TestMetamodelCornerCases.m
+++ b/Tests/Model/TestMetamodelCornerCases.m
@@ -9,6 +9,23 @@
 
 /**
  * This is meant to be a spec for corner cases in the metamodel.
+ *
+ * Q: do we support both aggregate and composite references (EMOF) or just
+ *    composite (FM3)?
+ *
+ * A: Following FM3's design, we don't support aggregate as a separate case.
+ *    The only point of supporting aggregate as a distinct concept from composite
+ *    would be to model relationships where a child can be in two containers
+ *    at once, but the relationship forbids cycles. This could maybe be
+ *    desirable for some kind of relationship representing tagging, but
+ *    until there's a concrete use case we're not supporting it.
+ *
+ *    Quentin: I would say that documenting/encoding a relationship as an
+ *    aggregation doesn't matter for ownership. As a result, it doesn't impact
+ *    the lifetime of the aggregated object and how it gets copied across object
+ *    graphs. So aggregation is useful to understand the relationships between
+ *    the objects but doesn't matter from an implementation/behavior perspective.
+ *    While composite matters from an implementation/behavior perspective.
  */
 @interface TestMetamodelCornerCases : EditingContextTestCase <UKTest>
 @end
@@ -30,31 +47,6 @@
 
     UKObjectsSame(data, [repo entityDescriptionForClass: [NSData class]]);
     UKObjectsSame(attachmentID, [repo entityDescriptionForClass: [COAttachmentID class]]);
-}
-
-/**
- * Q: do we support both aggregate and composite references (EMOF) or just
- *    composite (FM3)?
- *
- * A: Following FM3's design, we don't support aggregate as a separate case.
- *    The only point of supporting aggregate as a distinct concept from composite
- *    would be to model relationships where a child can be in two containers
- *    at once, but the relationship forbids cycles. This could maybe be
- *    desirable for some kind of relationship representing tagging, but
- *    until there's a concrete use case we're not supporting it.
- *
- *    Quentin: I would say that documenting/encoding a relationship as an 
- *    aggregation doesn't matter for ownership. As a result, it doesn't impact 
- *    the lifetime of the aggregated object and how it gets copied across object
- *    graphs. So aggregation is useful to understand the relationships between 
- *    the objects but doesn't matter from an implementation/behavior perspective.
- *    While composite matters from an implementation/behavior perspective.
- */
-- (void)testNoAggregate
-{
-    ETPropertyDescription *testProp = [ETPropertyDescription descriptionWithName: @"contents"
-                                                                        typeName: @"COObject"];
-    UKFalse([testProp respondsToSelector: @selector(setAggregate:)]);
 }
 
 #pragma mark -

--- a/Tests/Store/TestSQLiteStoreErrorHandling.m
+++ b/Tests/Store/TestSQLiteStoreErrorHandling.m
@@ -120,7 +120,7 @@ static ETUUID *rootUUID;
     NSString *dir = [self tempPathWithName: @"coreobject-index-become-readonly"];
 
     COPersistentRootInfo *info = nil;
-    int64_t changeCount;
+    __unused int64_t changeCount;
 
     @autoreleasepool
     {

--- a/Tests/TestModelObjects/FolderWithNoClass.h
+++ b/Tests/TestModelObjects/FolderWithNoClass.h
@@ -4,4 +4,4 @@
  * Creates an entity description that is the same as Folder, 
  * but with no COObject subclass.
  */
-void registerFolderWithNoClassEntityDescriptionIfNeeded();
+void registerFolderWithNoClassEntityDescriptionIfNeeded(void);

--- a/Tests/TestModelObjects/FolderWithNoClass.m
+++ b/Tests/TestModelObjects/FolderWithNoClass.m
@@ -7,7 +7,7 @@
 
 #import "FolderWithNoClass.h"
 
-void registerFolderWithNoClassEntityDescriptionIfNeeded()
+void registerFolderWithNoClassEntityDescriptionIfNeeded(void)
 {
     static BOOL registered;
     if (registered)

--- a/Tests/Undo/TestUndo.m
+++ b/Tests/Undo/TestUndo.m
@@ -736,7 +736,7 @@
 
 - (void)testUndoCoalescing
 {
-    CORevision *r0, *r1, *r2, *r3, *r4, *r5, *r6;
+    CORevision *r0, __unused *r1, *r2, __unused *r3, *r4, *r5, *r6;
     OutlineItem *item = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"].rootObject;
     [ctx commit];
     r0 = item.revision;

--- a/Undo/COUndoTrackStore+Private.h
+++ b/Undo/COUndoTrackStore+Private.h
@@ -102,7 +102,7 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
  *
  * This method must be run in the main thread.
  */
-- (BOOL)commitTransactionWithCompletionHandler: (void (^)())completion;
+- (BOOL)commitTransactionWithCompletionHandler: (void (^)(void))completion;
 
 
 /** @taskunit Managing Undo Tracks */

--- a/Undo/COUndoTrackStore.m
+++ b/Undo/COUndoTrackStore.m
@@ -307,7 +307,7 @@ NSString *const COUndoTrackStoreTrackCompacted = @"COUndoTrackStoreTrackCompacte
     return ok;
 }
 
-- (BOOL)commitTransactionWithCompletionHandler: (void (^)())completion
+- (BOOL)commitTransactionWithCompletionHandler: (void (^)(void))completion
 {
     ETAssert([NSThread isMainThread]);
     __block BOOL ok = NO;


### PR DESCRIPTION
Hi Eric,

I fixed warnings with the last Xcode version and updated the project to use the latest supported deployment targets.

I turned off a new warning about 'missing explicit self reference inside block', because it was causing hundreds of warnings. To fix it would require to add `self->property` in block-based tests, but I find it hurts readability, since we're using blocks everywhere in the tests.

There is one remaining warning: _TestMetamodelCornerCases.m:57:44 Undeclared selector 'setAggregate:'_. Although the documentation above `-testNoAggregate` does make sense to me, I don't get what the test is testing, since there is no `-setAggregate:` method in the metamodel. 

