### PR TITLE
Nullability and lightweight generics annotations for Store, Undo and Localization

### DIFF
--- a/Store/COBasicHistoryCompaction.h
+++ b/Store/COBasicHistoryCompaction.h
@@ -9,6 +9,8 @@
 #import <EtoileFoundation/EtoileFoundation.h>
 #import <CoreObject/COHistoryCompaction.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * @group Store
  * @abstract A basic compaction strategy used by 
@@ -30,24 +32,26 @@
  *
  * See -[COHistoryCompaction finalizablePersistentRootUUIDs].
  */
-@property (nonatomic, readwrite, copy) NSSet *finalizablePersistentRootUUIDs;
+@property (nonatomic, readwrite, copy) NSSet<ETUUID *> *finalizablePersistentRootUUIDs;
 /**
  * This method is only exposed to be used internally by CoreObject.
  *
  * See -[COHistoryCompaction compactablePersistentRootUUIDs].
  */
-@property (nonatomic, readwrite, copy) NSSet *compactablePersistentRootUUIDs;
+@property (nonatomic, readwrite, copy) NSSet<ETUUID *> *compactablePersistentRootUUIDs;
 /**
  * This method is only exposed to be used internally by CoreObject.
  *
  * See -[COHistoryCompaction finalizableBranchUUIDs].
  */
-@property (nonatomic, readwrite, copy) NSSet *finalizableBranchUUIDs;
+@property (nonatomic, readwrite, copy) NSSet<ETUUID *> *finalizableBranchUUIDs;
 /**
  * This method is only exposed to be used internally by CoreObject.
  *
  * See -[COHistoryCompaction compactableBranchUUIDs].
  */
-@property (nonatomic, readwrite, copy) NSSet *compactableBranchUUIDs;
+@property (nonatomic, readwrite, copy) NSSet<ETUUID *> *compactableBranchUUIDs;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COBranchInfo.h
+++ b/Store/COBranchInfo.h
@@ -9,6 +9,8 @@
 
 @class ETUUID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COBranchInfo : NSObject
 {
 @private
@@ -56,18 +58,20 @@
  * (If there is a real use case for unversioned persistent root metadata,
  *  we can easily re-add it)
  */
-@property (nonatomic, readwrite, copy) NSDictionary *metadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *metadata;
 @property (nonatomic, readwrite, getter=isDeleted) BOOL deleted;
-@property (nonatomic, readwrite, copy) ETUUID *parentBranchUUID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *parentBranchUUID;
 /**
  * In git terminology, if the receiver is "master", returns "origin/master", or
  * nil if there is no corresponding "origin/master"
  */
-@property (nonatomic, readonly) ETUUID *remoteMirror;
+@property (nonatomic, readonly, nullable) ETUUID *remoteMirror;
 /**
  * In git terminology, if the receiver is "origin/master", returns the UUID
  * of the "master" branch in the remote store "origin". Otherwise, returns nil.
  */
-@property (nonatomic, readonly) ETUUID *replcatedBranch;
+@property (nonatomic, readonly, nullable) ETUUID *replicatedBranch;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COBranchInfo.m
+++ b/Store/COBranchInfo.m
@@ -29,9 +29,9 @@
     return nil;
 }
 
-- (ETUUID *)replcatedBranch
+- (ETUUID *)replicatedBranch
 {
-    NSString *value = metadata_[@"replcatedBranch"];
+    NSString *value = metadata_[@"replicatedBranch"];
     if (value != nil)
     {
         return [ETUUID UUIDWithString: value];

--- a/Store/COHistoryCompaction.h
+++ b/Store/COHistoryCompaction.h
@@ -9,6 +9,8 @@
 #import <EtoileFoundation/EtoileFoundation.h>
 #import <CoreObject/COSQLiteStore.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * @group Store
  * @abstract A compaction strategy to free space in a CoreObject store.
@@ -46,7 +48,7 @@
  *
  * To attempt finalizing all persistent roots, return -compactablePersistentRootUUIDs.
  */
-@property (nonatomic, readonly, copy) NSSet *finalizablePersistentRootUUIDs;
+@property (nonatomic, readonly, copy) NSSet<ETUUID *> *finalizablePersistentRootUUIDs;
 /**
  * The persistent roots to be kept when compacting the history, but whose 
  * branches and revisions can be deleted.
@@ -57,7 +59,7 @@
  * If some of these persistent roots are returned among -finalizablePersistentRootUUIDs,
  * they will be finalized if marked as deleted, or compacted otherwise.
  */
-@property (nonatomic, readonly, copy) NSSet *compactablePersistentRootUUIDs;
+@property (nonatomic, readonly, copy) NSSet<ETUUID *> *compactablePersistentRootUUIDs;
 
 
 /** @taskunit Branch Status */
@@ -73,7 +75,7 @@
  *
  * To attempt finalizing all branches, return -compactableBranchUUIDs.
  */
-@property (nonatomic, readonly, copy) NSSet *finalizableBranchUUIDs;
+@property (nonatomic, readonly, copy) NSSet<ETUUID *> *finalizableBranchUUIDs;
 /**
  * The branches to be kept when compacting the history, but whose revisions can 
  * be deleted.
@@ -84,7 +86,7 @@
  * If some of these branches are returned among -finalizableBranchUUIDs and end
  * up being finalized, they will be ignored.
  */
-@property (nonatomic, readonly, copy) NSSet *compactableBranchUUIDs;
+@property (nonatomic, readonly, copy) NSSet<ETUUID *> *compactableBranchUUIDs;
 
 
 /** @taskunit Revision Status */
@@ -103,7 +105,7 @@
  * deleted (not yet implemented). No matter which revisions you return, this 
  * ensures you cannot accidentally create detached branches.
  */
-- (NSSet *)liveRevisionUUIDsForPersistentRootUUIDs: (NSArray *)persistentRootUUIDs;
+- (NSSet<ETUUID *> *)liveRevisionUUIDsForPersistentRootUUIDs: (NSArray<ETUUID *> *)persistentRootUUIDs;
 
 
 /** @taskunit Reacting to Compaction Progresses */
@@ -163,3 +165,5 @@
 - (BOOL)compactHistory: (id <COHistoryCompaction>)aCompactionStrategy;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COPersistentRootInfo.h
+++ b/Store/COPersistentRootInfo.h
@@ -9,6 +9,8 @@
 
 @class ETUUID, COBranchInfo;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Simple data structure returned by -[COSQLiteStore persistentRootInfoForUUID:]
  * to describe the entire state of a persistent root. It is a lightweight object
@@ -19,16 +21,16 @@
 @private
     ETUUID *uuid_;
     ETUUID *currentBranch_;
-    NSMutableDictionary *branchForUUID_; // COUUID : COBranchInfo
+    NSMutableDictionary<ETUUID *, COBranchInfo *> *branchForUUID_;
     BOOL _deleted;
     int64_t _transactionID;
-    NSDictionary *_metadata;
+    NSDictionary<NSString *, id> *_metadata;
 }
 
-@property (nonatomic, readonly) NSSet *branchUUIDs;
-@property (nonatomic, readonly) NSArray *branches;
+@property (nonatomic, readonly) NSSet<ETUUID *> *branchUUIDs;
+@property (nonatomic, readonly) NSArray<COBranchInfo *> *branches;
 
-- (COBranchInfo *)branchInfoForUUID: (ETUUID *)aUUID;
+- (nullable COBranchInfo *)branchInfoForUUID: (ETUUID *)aUUID;
 
 @property (nonatomic, readonly, strong) COBranchInfo *currentBranchInfo;
 /**
@@ -37,11 +39,13 @@
 @property (nonatomic, readonly) ETUUID *currentRevisionUUID;
 @property (nonatomic, readwrite, copy) ETUUID *UUID;
 @property (nonatomic, readwrite, copy) ETUUID *currentBranchUUID;
-@property (nonatomic, readwrite, copy) NSDictionary *branchForUUID;
+@property (nonatomic, readwrite, copy) NSDictionary<ETUUID *, COBranchInfo *> *branchForUUID;
 @property (nonatomic, readwrite, getter=isDeleted) BOOL deleted;
 @property (nonatomic, readwrite, assign) int64_t transactionID;
-@property (nonatomic, readwrite, copy) NSDictionary *metadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *metadata;
 
-- (NSArray *)branchInfosWithMetadataValue: (id)aValue forKey: (NSString *)aKey;
+- (NSArray<COBranchInfo *> *)branchInfosWithMetadataValue: (id)aValue forKey: (NSString *)aKey;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/CORevisionInfo.h
+++ b/Store/CORevisionInfo.h
@@ -8,6 +8,8 @@
 #import <Foundation/Foundation.h>
 #import <EtoileFoundation/ETUUID.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  Info about a commit. Parent revision (maybe nil), metadata, etc.
  *  There's a 1:1 mapping between a CORevisionID and CORevision per store.
@@ -25,14 +27,16 @@
 }
 
 @property (nonatomic, readwrite, copy) ETUUID *revisionUUID;
-@property (nonatomic, readwrite, copy) ETUUID *parentRevisionUUID;
-@property (nonatomic, readwrite, copy) ETUUID *mergeParentRevisionUUID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *parentRevisionUUID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *mergeParentRevisionUUID;
 @property (nonatomic, readwrite, copy) ETUUID *persistentRootUUID;
 @property (nonatomic, readwrite, copy) ETUUID *branchUUID;
-@property (readwrite, nonatomic, copy) NSDictionary *metadata;
+@property (readwrite, nonatomic, copy, nullable) NSDictionary<NSString *, id> *metadata;
 @property (nonatomic, readwrite, copy) NSDate *date;
 @property (nonatomic, readonly, strong) id plist;
 
 + (CORevisionInfo *)revisionInfoWithPlist: (id)aPlist;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COSQLiteStore+Attachments.h
+++ b/Store/COSQLiteStore+Attachments.h
@@ -7,10 +7,14 @@
 
 #import <CoreObject/CoreObject.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COSQLiteStore (Attachments)
 
-- (NSURL *)URLForAttachmentID: (COAttachmentID *)aHash;
-- (COAttachmentID *)importAttachmentFromURL: (NSURL *)aURL;
-- (COAttachmentID *)importAttachmentFromData: (NSData *)data;
+- (nullable NSURL *)URLForAttachmentID: (COAttachmentID *)aHash;
+- (nullable COAttachmentID *)importAttachmentFromURL: (NSURL *)aURL;
+- (nullable COAttachmentID *)importAttachmentFromData: (NSData *)data;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COSQLiteStore+Private.h
+++ b/Store/COSQLiteStore+Private.h
@@ -10,6 +10,8 @@
 
 @class COSQLiteStorePersistentRootBackingStore;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Private methods which are exposed so tests can look at the store internals.
  */
@@ -20,9 +22,9 @@
 
 - (BOOL)writeRevisionWithModifiedItems: (COItemGraph *)anItemTree
                           revisionUUID: (ETUUID *)aRevisionUUID
-                              metadata: (NSDictionary *)metadata
-                      parentRevisionID: (ETUUID *)aParent
-                 mergeParentRevisionID: (ETUUID *)aMergeParent
+                              metadata: (NSDictionary<NSString *, id> *)metadata
+                      parentRevisionID: (nullable ETUUID *)aParent
+                 mergeParentRevisionID: (nullable ETUUID *)aMergeParent
                     persistentRootUUID: (ETUUID *)aUUID
                             branchUUID: (ETUUID *)branch;
 - (COSQLiteStorePersistentRootBackingStore *)backingStoreForPersistentRootUUID: (ETUUID *)aUUID
@@ -30,3 +32,5 @@
 - (void)testingRunBlockInStoreQueue: (void (^)(void))aBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COSQLiteStore.h
+++ b/Store/COSQLiteStore.h
@@ -13,6 +13,8 @@
 @class COItem, CORevisionInfo, COItemGraph, COBranchInfo, COPersistentRootInfo;
 @class FMDatabase, COStoreTransaction;
 
+NS_ASSUME_NONNULL_BEGIN
+
 #define BACKING_STORES_SHARE_SAME_SQLITE_DB 1
 
 typedef NS_OPTIONS(NSUInteger, COBranchRevisionReadingOptions)
@@ -375,23 +377,27 @@ extern NSString *const COPersistentRootAttributeUsedSize;
  * 
  * Adding an in-memory cache for this will probably imporant.
  */
-- (CORevisionInfo *)revisionInfoForRevisionUUID: (ETUUID *)aRevision
-                             persistentRootUUID: (ETUUID *)aPersistentRoot;
+- (nullable CORevisionInfo *)revisionInfoForRevisionUUID: (ETUUID *)aRevision
+                                      persistentRootUUID: (ETUUID *)aPersistentRoot;
 /**
  * N.B. This is the only API for discovering divergent revisions
- * (revisions which aren't ancestors of the current revision of a branch)
+ * (revisions which aren't ancestors of the current revision of a branch).
+ * 
+ * Nil is returned when no backing store can be found for the branch UUID.
  *
  * NOTE: Unstable API
  */
-- (NSArray *)revisionInfosForBranchUUID: (ETUUID *)aBranchUUID
+- (nullable NSArray *)revisionInfosForBranchUUID: (ETUUID *)aBranchUUID
                                 options: (COBranchRevisionReadingOptions)options;
 /**
  * Returns all revision infos of the backing store where the given persistent
- * root is stored
+ * root is stored.
+ * 
+ * Nil is returned when no backing store can be found for the persistent root UUID.
  *
  * NOTE: Unstable API
  */
-- (NSArray<CORevisionInfo *> *)revisionInfosForBackingStoreOfPersistentRootUUID: (ETUUID *)aPersistentRoot;
+- (nullable NSArray<CORevisionInfo *> *)revisionInfosForBackingStoreOfPersistentRootUUID: (ETUUID *)aPersistentRoot;
 /**
  * Returns a delta between the given revision IDs.
  * The delta is uses the granularity of single inner objects, but not individual properties.
@@ -401,18 +407,18 @@ extern NSString *const COPersistentRootAttributeUsedSize;
  * In the future if we add an internal in-memory revision cache to COSQLiteStore, this may
  * no longer be of much use.
  */
-- (COItemGraph *)partialItemGraphFromRevisionUUID: (ETUUID *)baseRevid
-                                   toRevisionUUID: (ETUUID *)finalRevid
-                                   persistentRoot: (ETUUID *)aPersistentRoot;
+- (nullable COItemGraph *)partialItemGraphFromRevisionUUID: (ETUUID *)baseRevid
+                                            toRevisionUUID: (ETUUID *)finalRevid
+                                            persistentRoot: (ETUUID *)aPersistentRoot;
 /**
  * Returns the state the inner object graph at a given revision.
  */
-- (COItemGraph *)itemGraphForRevisionUUID: (ETUUID *)aRevisionUUID
-                           persistentRoot: (ETUUID *)aPersistentRoot;
+- (nullable COItemGraph *)itemGraphForRevisionUUID: (ETUUID *)aRevisionUUID
+                                    persistentRoot: (ETUUID *)aPersistentRoot;
 /**
  * Returns the UUID of the root object of the given persistent root.
  */
-- (ETUUID *)rootObjectUUIDForPersistentRoot: (ETUUID *)aPersistentRoot;
+- (nullable ETUUID *)rootObjectUUIDForPersistentRoot: (ETUUID *)aPersistentRoot;
 
 
 /** @taskunit Persistent Root Reading */
@@ -428,8 +434,8 @@ extern NSString *const COPersistentRootAttributeUsedSize;
  * @return  a snapshot of the state of a persistent root, or nil if
  *          the persistent root does not exist.
  */
-- (COPersistentRootInfo *)persistentRootInfoForUUID: (ETUUID *)aUUID;
-- (ETUUID *)persistentRootUUIDForBranchUUID: (ETUUID *)aBranchUUID;
+- (nullable COPersistentRootInfo *)persistentRootInfoForUUID: (ETUUID *)aUUID;
+- (nullable ETUUID *)persistentRootUUIDForBranchUUID: (ETUUID *)aBranchUUID;
 
 
 /** @taskunit Search. API not final. */
@@ -501,7 +507,7 @@ extern NSString *const COPersistentRootAttributeUsedSize;
  * Returns a dictionary of attributes describing the persistent root
  * such as COPersistentRootAttributeExportSize and COPersistentRootAttributeUsedSize
  */
-- (NSDictionary *)attributesForPersistentRootWithUUID: (ETUUID *)aUUID;
+- (nullable NSDictionary *)attributesForPersistentRootWithUUID: (ETUUID *)aUUID;
 
 
 /** @taskunit Description */
@@ -518,3 +524,5 @@ extern NSString *const COPersistentRootAttributeUsedSize;
 @property (nonatomic, readonly) NSString *detailedDescription;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COSQLiteStore.h
+++ b/Store/COSQLiteStore.h
@@ -434,7 +434,7 @@ extern NSString *const COPersistentRootAttributeUsedSize;
  * @return  a snapshot of the state of a persistent root, or nil if
  *          the persistent root does not exist.
  */
-- (nullable COPersistentRootInfo *)persistentRootInfoForUUID: (ETUUID *)aUUID;
+- (nullable COPersistentRootInfo *)persistentRootInfoForUUID: (nullable ETUUID *)aUUID;
 - (nullable ETUUID *)persistentRootUUIDForBranchUUID: (ETUUID *)aBranchUUID;
 
 

--- a/Store/COSQLiteStore.h
+++ b/Store/COSQLiteStore.h
@@ -355,6 +355,7 @@ extern NSString *const COPersistentRootAttributeUsedSize;
  * Opens an exisiting, or creates a new CoreObject store at the given file:// URL.
  */
 - (instancetype)initWithURL: (NSURL *)aURL NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  * Returns the file:// URL the receiver was created with.

--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -107,10 +107,15 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
     return self;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+
 - (instancetype)init
 {
     return [self initWithURL: nil];
 }
+
+#pragma clang diagnostic pop
 
 - (void)dealloc
 {

--- a/Store/COSQLiteStorePersistentRootBackingStore.h
+++ b/Store/COSQLiteStorePersistentRootBackingStore.h
@@ -13,6 +13,8 @@
 @class COItemGraph;
 @class CORevisionInfo;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Database connection for manipulating a persistent root backing store.
  *
@@ -39,18 +41,19 @@
 - (instancetype)initWithPersistentRootUUID: (ETUUID *)aUUID
                                      store: (COSQLiteStore *)store
                                 useStoreDB: (BOOL)share
-                                     error: (NSError **)error NS_DESIGNATED_INITIALIZER;
+                                     error: (NSError *_Nullable *_Nullable)error NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
 
 @property (nonatomic, readonly) BOOL close;
 
-- (CORevisionInfo *)revisionInfoForRevisionUUID: (ETUUID *)aToken;
+- (nullable CORevisionInfo *)revisionInfoForRevisionUUID: (ETUUID *)aToken;
 
 @property (nonatomic, readonly, strong) ETUUID *UUID;
 @property (nonatomic, readonly, strong) ETUUID *rootUUID;
 
 - (BOOL)hasRevid: (int64_t)revid;
 - (COItemGraph *)itemGraphForRevid: (int64_t)revid;
-- (COItemGraph *)itemGraphForRevid: (int64_t)revid restrictToItemUUIDs: (NSSet *)itemSet;
+- (COItemGraph *)itemGraphForRevid: (int64_t)revid restrictToItemUUIDs: (nullable NSSet<ETUUID *> *)itemSet;
 /**
  * baseRevid must be < finalRevid.
  * returns nil if baseRevid or finalRevid are not valid revisions.
@@ -58,15 +61,15 @@
 - (COItemGraph *)partialItemGraphFromRevid: (int64_t)baseRevid toRevid: (int64_t)finalRevid;
 - (COItemGraph *)partialItemGraphFromRevid: (int64_t)baseRevid
                                    toRevid: (int64_t)revid
-                       restrictToItemUUIDs: (NSSet *)itemSet;
+                       restrictToItemUUIDs: (nullable NSSet<ETUUID *> *)itemSet;
 - (BOOL)writeItemGraph: (COItemGraph *)anItemTree
           revisionUUID: (ETUUID *)aRevisionUUID
-          withMetadata: (NSDictionary *)metadata
+          withMetadata: (nullable NSDictionary<NSString *, id> *)metadata
             withParent: (int64_t)aParent
        withMergeParent: (int64_t)aMergeParent
             branchUUID: (ETUUID *)aBranchUUID
     persistentrootUUID: (ETUUID *)aPersistentRootUUID
-                 error: (NSError **)error;
+                 error: (NSError *_Nullable *_Nullable)error;
 - (NSIndexSet *)revidsFromRevid: (int64_t)baseRevid toRevid: (int64_t)finalRevid;
 /**
  * Unconditionally deletes the specified revisions
@@ -83,10 +86,10 @@
 
 - (int64_t)revidForUUID: (ETUUID *)aUUID;
 - (NSIndexSet *)revidsForUUIDs: (NSArray *)UUIDs;
-- (ETUUID *)revisionUUIDForRevid: (int64_t)aRevid;
-- (NSArray *)revisionInfosForBranchUUID: (ETUUID *)aBranchUUID
-                       headRevisionUUID: (ETUUID *)aHeadRevUUID
-                                options: (COBranchRevisionReadingOptions)options;
+- (nullable ETUUID *)revisionUUIDForRevid: (int64_t)aRevid;
+- (NSArray<CORevisionInfo *> *)revisionInfosForBranchUUID: (ETUUID *)aBranchUUID
+                                         headRevisionUUID: (nullable ETUUID *)aHeadRevUUID
+                                                  options: (COBranchRevisionReadingOptions)options;
 
 @property (nonatomic, readonly) NSArray *revisionInfos;
 @property (nonatomic, readonly) uint64_t fileSize;
@@ -97,3 +100,5 @@
 @end
 
 NSData *contentsBLOBWithItemTree(id <COItemGraph> itemGraph);
+
+NS_ASSUME_NONNULL_END

--- a/Store/COSQLiteStorePersistentRootBackingStore.m
+++ b/Store/COSQLiteStorePersistentRootBackingStore.m
@@ -141,10 +141,16 @@
     return self;
 }
 
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+
 - (instancetype)init
 {
     return [self initWithPersistentRootUUID: nil store: nil useStoreDB: NO error: NULL];
 }
+
+#pragma clang diagnostic pop
 
 - (void)clearBackingStore
 {

--- a/Store/COSQLiteStorePersistentRootBackingStoreBinaryFormats.h
+++ b/Store/COSQLiteStorePersistentRootBackingStoreBinaryFormats.h
@@ -9,14 +9,16 @@
 
 @class ETUUID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Given an NSData produced by AddCommitUUIDAndDataToCombinedCommitData,
  * extracts the UUID : NSData pairs within it and adds them to dest
  */
-void ParseCombinedCommitDataInToUUIDToItemDataDictionary(NSMutableDictionary *dest,
+void ParseCombinedCommitDataInToUUIDToItemDataDictionary(NSMutableDictionary<ETUUID *, NSData *> *dest,
                                                          NSData *commitData,
                                                          BOOL replaceExisting,
-                                                         NSSet *restrictToItemUUIDs);
+                                                         NSSet<ETUUID *>  *_Nullable restrictToItemUUIDs);
 
 /**
  * Adds a COUUID : NSData pair to combinedCommitData
@@ -24,3 +26,5 @@ void ParseCombinedCommitDataInToUUIDToItemDataDictionary(NSMutableDictionary *de
 void AddCommitUUIDAndDataToCombinedCommitData(NSMutableData *combinedCommitData,
                                               ETUUID *uuidToAdd,
                                               NSData *dataToAdd);
+
+NS_ASSUME_NONNULL_END

--- a/Store/COSQLiteUtilities.h
+++ b/Store/COSQLiteUtilities.h
@@ -8,6 +8,10 @@
 #import <CoreObject/CoreObject.h>
 #include <dispatch/dispatch.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 void dispatch_sync_now(dispatch_queue_t queue, dispatch_block_t block);
 
-NSDictionary *pageStatisticsForDatabase(FMDatabase *db);
+NSDictionary<NSString *, NSNumber *> *pageStatisticsForDatabase(FMDatabase *db);
+
+NS_ASSUME_NONNULL_END

--- a/Store/COSearchResult.h
+++ b/Store/COSearchResult.h
@@ -9,10 +9,14 @@
 
 @class ETUUID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COSearchResult : NSObject
 
 @property (nonatomic, readwrite, copy) ETUUID *persistentRoot;
 @property (nonatomic, readwrite, copy) ETUUID *revision;
-@property (nonatomic, readwrite, copy) ETUUID *innerObjectUUID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *innerObjectUUID;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreAction.h
+++ b/Store/COStoreAction.h
@@ -9,6 +9,8 @@
 
 @class COSQLiteStore, COStoreTransaction;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol COStoreAction <NSObject>
 
 @property (nonatomic, readwrite, copy) ETUUID *persistentRoot;
@@ -16,3 +18,5 @@
 - (BOOL)execute: (COSQLiteStore *)store inTransaction: (COStoreTransaction *)aTransaction;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreCreateBranch.h
+++ b/Store/COStoreCreateBranch.h
@@ -8,6 +8,8 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreCreateBranch : NSObject <COStoreAction>
 
 @property (nonatomic, retain, readwrite) ETUUID *branch;
@@ -15,3 +17,5 @@
 @property (nonatomic, retain, readwrite) ETUUID *initialRevision;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreCreatePersistentRoot.h
+++ b/Store/COStoreCreatePersistentRoot.h
@@ -8,6 +8,8 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Creates an empty persistent root (with no branches).
  * If persistentRootForCopy is set, shares a backing store with that persistent
@@ -15,6 +17,8 @@
  */
 @interface COStoreCreatePersistentRoot : NSObject <COStoreAction>
 
-@property (nonatomic, retain, readwrite) ETUUID *persistentRootForCopy;
+@property (nonatomic, retain, readwrite, nullable) ETUUID *persistentRootForCopy;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreDeleteBranch.h
+++ b/Store/COStoreDeleteBranch.h
@@ -8,8 +8,12 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreDeleteBranch : NSObject <COStoreAction>
 
 @property (nonatomic, retain, readwrite) ETUUID *branch;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreDeletePersistentRoot.h
+++ b/Store/COStoreDeletePersistentRoot.h
@@ -8,5 +8,9 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreDeletePersistentRoot : NSObject <COStoreAction>
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreSetBranchMetadata.h
+++ b/Store/COStoreSetBranchMetadata.h
@@ -8,9 +8,13 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreSetBranchMetadata : NSObject <COStoreAction>
 
 @property (nonatomic, retain, readwrite) ETUUID *branch;
-@property (nonatomic, retain, readwrite) NSDictionary *metadata;
+@property (nonatomic, retain, readwrite, nullable) NSDictionary<NSString *, id> *metadata;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreSetCurrentBranch.h
+++ b/Store/COStoreSetCurrentBranch.h
@@ -8,8 +8,12 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreSetCurrentBranch : NSObject <COStoreAction>
 
 @property (nonatomic, retain, readwrite) ETUUID *branch;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreSetCurrentRevision.h
+++ b/Store/COStoreSetCurrentRevision.h
@@ -8,10 +8,14 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreSetCurrentRevision : NSObject <COStoreAction>
 
 @property (nonatomic, retain, readwrite) ETUUID *branch;
 @property (nonatomic, retain, readwrite) ETUUID *currentRevision;
-@property (nonatomic, retain, readwrite) ETUUID *headRevision;
+@property (nonatomic, retain, readwrite, nullable) ETUUID *headRevision;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreSetPersistentRootMetadata.h
+++ b/Store/COStoreSetPersistentRootMetadata.h
@@ -8,8 +8,12 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreSetPersistentRootMetadata : NSObject <COStoreAction>
 
-@property (nonatomic, retain, readwrite) NSDictionary *metadata;
+@property (nonatomic, retain, readwrite, nullable) NSDictionary<NSString *, id> *metadata;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreTransaction.h
+++ b/Store/COStoreTransaction.h
@@ -7,6 +7,10 @@
 
 #import <CoreObject/CoreObject.h>
 
+@protocol COStoreAction;
+
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Builder object for creating a batch of changes to write to the store.
  *
@@ -26,7 +30,7 @@
     NSMutableDictionary *_oldTransactionIDForPersistentRootUUID;
 }
 
-@property (nonatomic, readonly, strong) NSMutableArray *operations;
+@property (nonatomic, readonly, strong) NSMutableArray<id <COStoreAction>> *operations;
 
 /** @taskunit Transaction ID */
 
@@ -55,9 +59,9 @@
 
 - (void)writeRevisionWithModifiedItems: (COItemGraph *)anItemTree
                           revisionUUID: (ETUUID *)aRevisionUUID
-                              metadata: (NSDictionary *)metadata
-                      parentRevisionID: (ETUUID *)aParent
-                 mergeParentRevisionID: (ETUUID *)aMergeParent
+                              metadata: (nullable NSDictionary<NSString *, id> *)metadata
+                      parentRevisionID: (nullable ETUUID *)aParent
+                 mergeParentRevisionID: (nullable ETUUID *)aMergeParent
                     persistentRootUUID: (ETUUID *)aUUID
                             branchUUID: (ETUUID *)branch;
 
@@ -66,14 +70,14 @@
 
 
 - (void)createPersistentRootWithUUID: (ETUUID *)persistentRootUUID
-               persistentRootForCopy: (ETUUID *)persistentRootForCopyUUID;
+               persistentRootForCopy: (nullable ETUUID *)persistentRootForCopyUUID;
 /**
  * Convenience method
  */
 - (COPersistentRootInfo *)createPersistentRootCopyWithUUID: (ETUUID *)uuid
-                                  parentPersistentRootUUID: (ETUUID *)aParentPersistentRoot
+                                  parentPersistentRootUUID: (nullable ETUUID *)aParentPersistentRoot
                                                 branchUUID: (ETUUID *)aBranchUUID
-                                          parentBranchUUID: (ETUUID *)aParentBranch
+                                          parentBranchUUID: (nullable ETUUID *)aParentBranch
                                        initialRevisionUUID: (ETUUID *)aRevision;
 /**
  * Convenience method
@@ -81,7 +85,7 @@
 - (COPersistentRootInfo *)createPersistentRootWithInitialItemGraph: (COItemGraph *)contents
                                                               UUID: (ETUUID *)persistentRootUUID
                                                         branchUUID: (ETUUID *)aBranchUUID
-                                                  revisionMetadata: (NSDictionary *)metadata;
+                                                  revisionMetadata: (nullable NSDictionary<NSString *, id> *)metadata;
 
 
 /** @taskunit Persistent Root Modification */
@@ -94,7 +98,7 @@
 - (void)setCurrentBranch: (ETUUID *)aBranch
        forPersistentRoot: (ETUUID *)aRoot;
 - (void)createBranchWithUUID: (ETUUID *)branchUUID
-                parentBranch: (ETUUID *)aParentBranch
+                parentBranch: (nullable ETUUID *)aParentBranch
              initialRevision: (ETUUID *)revId
            forPersistentRoot: (ETUUID *)aRoot;
 /**
@@ -102,13 +106,13 @@
  * You can pass nil for headRev to not change the headRev.
  */
 - (void)setCurrentRevision: (ETUUID *)currentRev
-              headRevision: (ETUUID *)headRev
+              headRevision: (nullable ETUUID *)headRev
                  forBranch: (ETUUID *)aBranch
           ofPersistentRoot: (ETUUID *)aRoot;
-- (void)setMetadata: (NSDictionary *)metadata
+- (void)setMetadata: (nullable NSDictionary<NSString *, id> *)metadata
           forBranch: (ETUUID *)aBranch
    ofPersistentRoot: (ETUUID *)aRoot;
-- (void)setMetadata: (NSDictionary *)metadata
+- (void)setMetadata: (nullable NSDictionary<NSString *, id> *)metadata
   forPersistentRoot: (ETUUID *)aRoot;
 
 
@@ -147,7 +151,9 @@
  *
  * Returns nil if the branch's current revision is not modified in this transaction.
  */
-- (ETUUID *)lastSetCurrentRevisionInTransactionForBranch: (ETUUID *)aBranch
-                                        ofPersistentRoot: (ETUUID *)aRoot;
+- (nullable ETUUID *)lastSetCurrentRevisionInTransactionForBranch: (ETUUID *)aBranch
+                                                 ofPersistentRoot: (ETUUID *)aRoot;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreUndeleteBranch.h
+++ b/Store/COStoreUndeleteBranch.h
@@ -8,8 +8,12 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreUndeleteBranch : NSObject <COStoreAction>
 
 @property (nonatomic, retain, readwrite) ETUUID *branch;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreUndeletePersistentRoot.h
+++ b/Store/COStoreUndeletePersistentRoot.h
@@ -8,5 +8,9 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreUndeletePersistentRoot : NSObject <COStoreAction>
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Store/COStoreWriteRevision.h
+++ b/Store/COStoreWriteRevision.h
@@ -8,13 +8,17 @@
 #import <CoreObject/CoreObject.h>
 #import "CoreObject/COStoreAction.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COStoreWriteRevision : NSObject <COStoreAction>
 
 @property (nonatomic, retain, readwrite) COItemGraph *modifiedItems;
 @property (nonatomic, retain, readwrite) ETUUID *revisionUUID;
-@property (nonatomic, retain, readwrite) ETUUID *parentRevisionUUID;
-@property (nonatomic, retain, readwrite) ETUUID *mergeParentRevisionUUID;
+@property (nonatomic, retain, readwrite, nullable) ETUUID *parentRevisionUUID;
+@property (nonatomic, retain, readwrite, nullable) ETUUID *mergeParentRevisionUUID;
 @property (nonatomic, retain, readwrite) ETUUID *branch;
-@property (nonatomic, retain, readwrite) NSDictionary *metadata;
+@property (nonatomic, retain, readwrite, nullable) NSDictionary<NSString *, id> *metadata;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Synchronization/COSynchronizationClient.m
+++ b/Synchronization/COSynchronizationClient.m
@@ -163,7 +163,7 @@ static void InsertRevisions(NSDictionary *revisionsPlist,
         for (COBranchInfo *branch in info.branches)
         {
             if ([branch.metadata[@"source"] isEqual: serverID]
-                && [branch.metadata[@"replcatedBranch"] isEqual: branchUUIDString])
+                && [branch.metadata[@"replicatedBranch"] isEqual: branchUUIDString])
             {
                 branchToUpdate = branch;
                 break;
@@ -185,7 +185,7 @@ static void InsertRevisions(NSDictionary *revisionsPlist,
                       initialRevision: currentRevisionID
                     forPersistentRoot: persistentRoot];
 
-            [txn setMetadata: @{@"source": serverID, @"replcatedBranch": branchUUIDString}
+            [txn setMetadata: @{@"source": serverID, @"replicatedBranch": branchUUIDString}
                    forBranch: branchUUID
             ofPersistentRoot: persistentRoot];
         }

--- a/Tests/Synchronization/TestSynchronization.m
+++ b/Tests/Synchronization/TestSynchronization.m
@@ -121,11 +121,11 @@ static ETUUID *branchBUUID;
 
     COBranchInfo *currentBranch = clientInfo.currentBranchInfo;
     COBranchInfo *replicatedBranchA = [[clientInfo branchInfosWithMetadataValue: [branchAUUID stringValue]
-                                                                         forKey: @"replcatedBranch"] firstObject];
+                                                                         forKey: @"replicatedBranch"] firstObject];
 
 
     COBranchInfo *replicatedBranchB = [[clientInfo branchInfosWithMetadataValue: [branchBUUID stringValue]
-                                                                         forKey: @"replcatedBranch"] firstObject];
+                                                                         forKey: @"replicatedBranch"] firstObject];
 
     // Check out the 3 branches
     UKObjectsEqual(branchAUUID, currentBranch.UUID);
@@ -219,7 +219,7 @@ static ETUUID *branchBUUID;
     COBranchInfo *currentBranch = clientInfo.currentBranchInfo;
 
     COBranchInfo *replicatedBranchA = [[clientInfo branchInfosWithMetadataValue: [branchAUUID stringValue]
-                                                                         forKey: @"replcatedBranch"] firstObject];
+                                                                         forKey: @"replicatedBranch"] firstObject];
 
     UKTrue([replicatedBranchA.metadata[@"source"] isEqual: @"server"]);
 
@@ -303,7 +303,7 @@ static ETUUID *branchBUUID;
     
     COBranchInfo *currentBranch = clientCheapCopyInfo.currentBranchInfo;
     COBranchInfo *replicatedCheapCopyBranch = [[clientCheapCopyInfo branchInfosWithMetadataValue: [cheapCopyBranchUUID stringValue]
-                                                                                          forKey: @"replcatedBranch"] firstObject];
+                                                                                          forKey: @"replicatedBranch"] firstObject];
 
     UKObjectsEqual(cheapCopyBranchUUID, currentBranch.UUID);
     UKObjectsNotEqual(cheapCopyBranchUUID, replicatedCheapCopyBranch.UUID);
@@ -381,7 +381,7 @@ static ETUUID *branchBUUID;
     COBranchInfo *currentBranch = serverInfo.currentBranchInfo;
 
     COBranchInfo *replicatedBranchA = [[serverInfo branchInfosWithMetadataValue: [branchAUUID stringValue]
-                                                                         forKey: @"replcatedBranch"] firstObject];
+                                                                         forKey: @"replicatedBranch"] firstObject];
 
     UKTrue([replicatedBranchA.metadata[@"source"] isEqual: @"client"]);
 
@@ -453,7 +453,7 @@ static ETUUID *branchBUUID;
         NSSet *serverRemoteBranches = [serverPersistentRoot.branches filteredCollectionWithBlock: ^(
             COBranch *obj)
         {
-            return (BOOL)(obj.metadata[@"replcatedBranch"] != nil);
+            return (BOOL)(obj.metadata[@"replicatedBranch"] != nil);
         }];
         UKIntsEqual(1, serverRemoteBranches.count);
         COBranch *serverRemoteBranch = [serverRemoteBranches anyObject];
@@ -495,7 +495,7 @@ static ETUUID *branchBUUID;
         NSSet *serverRemoteBranches = [serverPersistentRoot.branches filteredCollectionWithBlock: ^(
             COBranch *obj)
         {
-            return (BOOL)(obj.metadata[@"replcatedBranch"] != nil);
+            return (BOOL)(obj.metadata[@"replicatedBranch"] != nil);
         }];
         UKIntsEqual(1, serverRemoteBranches.count);
         COBranch *serverRemoteBranch = [serverRemoteBranches anyObject];

--- a/Tests/Undo/TestUndoTrack.m
+++ b/Tests/Undo/TestUndoTrack.m
@@ -527,7 +527,7 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     [_track recordCommand: group2];
     [_track undoNode: (id <COTrackNode>)group1];
 
-    COCommandGroup *undoGroup1 = _track.nodes.lastObject;
+    COCommandGroup *undoGroup1 = (COCommandGroup *)_track.nodes.lastObject;
 
     UKObjectsNotEqual(group1, undoGroup1);
     UKObjectsEqual(group1.parentUndoTrack, undoGroup1.parentUndoTrack);
@@ -553,7 +553,7 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     [_track recordCommand: group2];
     [_patternTrack undoNode: _patternTrack.nodes[1]];
 
-    COCommandGroup *undoGroup1 = _patternTrack.nodes.lastObject;
+    COCommandGroup *undoGroup1 = (COCommandGroup *)_patternTrack.nodes.lastObject;
 
     UKObjectsEqual(undoGroup1, _track.nodes.lastObject);
 
@@ -583,7 +583,7 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     [_track recordCommand: group2];
     [_track redoNode: (id <COTrackNode>)group1];
 
-    COCommandGroup *redoGroup1 = _track.nodes.lastObject;
+    COCommandGroup *redoGroup1 = (COCommandGroup *)_track.nodes.lastObject;
 
     UKObjectsNotEqual(group1, redoGroup1);
     UKObjectsEqual(group1.parentUndoTrack, redoGroup1.parentUndoTrack);
@@ -609,7 +609,7 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     [_track recordCommand: group2];
     [_patternTrack redoNode: (id <COTrackNode>)group1];
 
-    COCommandGroup *redoGroup1 = _patternTrack.nodes.lastObject;
+    COCommandGroup *redoGroup1 = (COCommandGroup *)_patternTrack.nodes.lastObject;
 
     UKObjectsNotEqual(group1, redoGroup1);
     UKObjectsNotEqual(group1.parentUndoTrack, redoGroup1.parentUndoTrack);

--- a/Tests/Undo/TestUndoTrackHistoryCompaction.m
+++ b/Tests/Undo/TestUndoTrackHistoryCompaction.m
@@ -27,10 +27,15 @@
 
 @dynamic finalizablePersistentRootUUIDs, compactablePersistentRootUUIDs, deadRevisionUUIDs, liveRevisionUUIDs;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 - (instancetype)init
 {
     return self;
 }
+
+#pragma clang diagnostic pop
 
 - (void)setFinalizablePersistentRootUUIDs: (NSSet *)finalizablePersistentRootUUIDs
 {

--- a/Undo/COCommand.h
+++ b/Undo/COCommand.h
@@ -11,6 +11,8 @@
 
 @class COEditingContext, COUndoTrack;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * @group Undo
  * @abstract A command represents a committed change in an editing context
@@ -66,11 +68,11 @@
  *
  * An atomic command belongs to a command group which has a parent command.
  */
-@property (nonatomic, readonly) id <COTrackNode> parentNode;
+@property (nonatomic, readonly, nullable) id <COTrackNode> parentNode;
 /**
  * Returns nil.
  */
-@property (nonatomic, readonly) id <COTrackNode> mergeParentNode;
+@property (nonatomic, readonly, nullable) id <COTrackNode> mergeParentNode;
 
 
 /** @taskunit Applying and Reverting Changes */
@@ -110,7 +112,7 @@
  * Applies the receiver changes directly to a store transaction.
  */
 - (void)addToStoreTransaction: (COStoreTransaction *)txn
-         withRevisionMetadata: (NSDictionary *)metadata
+         withRevisionMetadata: (nullable NSDictionary<NSString *, id> *)metadata
   assumingEditingContextState: (COEditingContext *)ctx;
 
 
@@ -147,3 +149,6 @@
 - (id)copyWithZone: (NSZone *)zone;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/Undo/COCommandDeleteBranch.h
+++ b/Undo/COCommandDeleteBranch.h
@@ -7,6 +7,8 @@
 
 #import <CoreObject/COCommand.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COCommandDeleteBranch : COCommand
 {
     ETUUID *_branchUUID;
@@ -15,3 +17,5 @@
 @property (nonatomic, readwrite, copy) ETUUID *branchUUID;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COCommandDeletePersistentRoot.h
+++ b/Undo/COCommandDeletePersistentRoot.h
@@ -7,6 +7,8 @@
 
 #import <CoreObject/COCommand.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COCommandDeletePersistentRoot : COCommand
 {
 @private
@@ -20,6 +22,8 @@
  * If the command is a undelete inverse or was not obtained using 
  * -[COCommand inverse], returns nil.
  */
-@property (nonatomic, readwrite, copy) ETUUID *initialRevisionID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *initialRevisionID;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COCommandGroup.h
+++ b/Undo/COCommandGroup.h
@@ -11,6 +11,8 @@
 @class COCommitDescriptor;
 @class COUndoTrackSerializedCommand;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * @group Undo
  * @abstract A command group represents a commit done in an editing context
@@ -66,18 +68,18 @@
  *
  * Cannot contain COCommandGroup objects.
  */
-@property (nonatomic, readwrite, copy) NSMutableArray *contents;
+@property (nonatomic, readwrite, copy) NSMutableArray<COCommand *> *contents;
 /**
  * The commit metadata.
  */
-@property (nonatomic, readwrite, copy) NSDictionary *metadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *metadata;
 /**
  * The commit descriptor matching the commit identifier in -metadata.
  *
  * COCommand overrides -localizedTypeDescription and -localizedShortDescription 
  * to return the equivalent commit descriptor descriptions.
  */
-@property (nonatomic, readonly) COCommitDescriptor *commitDescriptor;
+@property (nonatomic, readonly, nullable) COCommitDescriptor *commitDescriptor;
 /**
  * The UUID of the parent command. 
  *
@@ -100,7 +102,7 @@
  *
  * See also -[COUndoTrack childrenOfNode:].
  */
-@property (nonatomic, readwrite, copy) ETUUID *parentUUID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *parentUUID;
 /**
  * The commit time.
  */
@@ -115,11 +117,11 @@
  * Returns [COEndOfUndoTrackPlaceholderNode sharedInstance] for the first 
  * recorded COCommandGroup(s) on a track.
  */
-@property (nonatomic, readonly) id <COTrackNode> parentNode;
+@property (nonatomic, readonly, nullable) id <COTrackNode> parentNode;
 /**
  * Returns nil.
  */
-@property (nonatomic, readonly) id <COTrackNode> mergeParentNode;
+@property (nonatomic, readonly, nullable) id <COTrackNode> mergeParentNode;
 
 
 /** @taskunit Applying and Reverting Changes */
@@ -147,7 +149,7 @@
  * Applies the receiver changes directly to a store transaction.
  */
 - (void)addToStoreTransaction: (COStoreTransaction *)txn
-         withRevisionMetadata: (NSDictionary *)metadata
+         withRevisionMetadata: (NSDictionary<NSString *, id> *)metadata
   assumingEditingContextState: (COEditingContext *)ctx;
 
 
@@ -155,12 +157,16 @@
 
 
 /**
+ * Initializes an empty command group with no parent undo track.
+ */
+- (instancetype)init;
+/**
  * <init />
  * Initializes a command group from a serialized represention and with a parent 
  * undo track.
  */
 - (instancetype)initWithSerializedCommand: (COUndoTrackSerializedCommand *)aCommand
-                                    owner: (COUndoTrack *)anOwner NS_DESIGNATED_INITIALIZER;
+                                    owner: (nullable COUndoTrack *)anOwner NS_DESIGNATED_INITIALIZER;
 
 /**
  * Returns a serialized represention.
@@ -168,3 +174,5 @@
 @property (nonatomic, readonly, strong) COUndoTrackSerializedCommand *serializedCommand;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COCommandSetBranchMetadata.h
+++ b/Undo/COCommandSetBranchMetadata.h
@@ -7,6 +7,8 @@
 
 #import <CoreObject/COCommand.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COCommandSetBranchMetadata : COCommand
 {
     ETUUID *_branchUUID;
@@ -15,7 +17,10 @@
 }
 
 @property (nonatomic, readwrite, copy) ETUUID *branchUUID;
-@property (nonatomic, readwrite, copy) NSDictionary *oldMetadata;
-@property (nonatomic, readwrite, copy) NSDictionary *metadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *oldMetadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *metadata;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/Undo/COCommandSetCurrentBranch.h
+++ b/Undo/COCommandSetCurrentBranch.h
@@ -7,6 +7,8 @@
 
 #import <CoreObject/COCommand.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COCommandSetCurrentBranch : COCommand
 {
     ETUUID *_oldBranchUUID;
@@ -17,3 +19,5 @@
 @property (nonatomic, readwrite, copy) ETUUID *branchUUID;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COCommandSetCurrentVersionForBranch.h
+++ b/Undo/COCommandSetCurrentVersionForBranch.h
@@ -9,6 +9,8 @@
 
 @class CORevision;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COCommandSetCurrentVersionForBranch : COCommand
 {
     ETUUID *_branchUUID;
@@ -53,12 +55,14 @@
  *
  * See -[CORevision metadata].
  */
-@property (nonatomic, readonly) NSDictionary *metadata;
+@property (nonatomic, readonly, nullable) NSDictionary<NSString *, id> *metadata;
 /**
  * Returns the short description for the set revision.
  *
  * See -[CORevision localizedShortDescription].
  */
-@property (nonatomic, readonly) NSString *localizedShortDescription;
+@property (nonatomic, readonly, nullable) NSString *localizedShortDescription;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COCommandSetPersistentRootMetadata.h
+++ b/Undo/COCommandSetPersistentRootMetadata.h
@@ -7,13 +7,18 @@
 
 #import <CoreObject/COCommand.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COCommandSetPersistentRootMetadata : COCommand
 {
     NSDictionary *_oldMetadata;
     NSDictionary *_newMetadata;
 }
 
-@property (nonatomic, readwrite, copy) NSDictionary *oldMetadata;
-@property (nonatomic, readwrite, copy) NSDictionary *metadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *oldMetadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *metadata;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/Undo/COCommandUndeleteBranch.h
+++ b/Undo/COCommandUndeleteBranch.h
@@ -7,6 +7,8 @@
 
 #import <CoreObject/COCommand.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COCommandUndeleteBranch : COCommand
 {
     ETUUID *_branchUUID;
@@ -15,3 +17,5 @@
 @property (nonatomic, readwrite, copy) ETUUID *branchUUID;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COCommandUndeletePersistentRoot.h
+++ b/Undo/COCommandUndeletePersistentRoot.h
@@ -7,9 +7,10 @@
 
 #import <CoreObject/COCommand.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COCommandUndeletePersistentRoot : COCommand
 @end
-
 
 @interface COCommandCreatePersistentRoot : COCommandUndeletePersistentRoot
 {
@@ -23,3 +24,5 @@
 @property (nonatomic, readwrite, copy) ETUUID *initialRevisionID;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COEditingContext+Undo.h
+++ b/Undo/COEditingContext+Undo.h
@@ -9,6 +9,8 @@
 
 @class COUndoTrack, COCommand;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Goals for the app level undo system:
  *
@@ -56,8 +58,8 @@
 
 // Called from COEditingContext
 
-- (void)recordBeginUndoGroupWithMetadata: (NSDictionary *)metadata;
-- (COCommandGroup *)recordEndUndoGroupWithUndoTrack: (COUndoTrack *)track;
+- (void)recordBeginUndoGroupWithMetadata: (nullable NSDictionary<NSString *, id> *)metadata;
+- (COCommandGroup *)recordEndUndoGroupWithUndoTrack: (nullable COUndoTrack *)track;
 - (void)recordPersistentRootDeletion: (COPersistentRoot *)aPersistentRoot;
 - (void)recordPersistentRootUndeletion: (COPersistentRoot *)aPersistentRoot;
 
@@ -69,7 +71,7 @@
             setCurrentBranch: (COBranch *)aBranch
                    oldBranch: (COBranch *)oldBranch;
 - (void)recordPersistentRootSetMetadata: (COPersistentRoot *)aPersistentRoot
-                            oldMetadata: (id)oldMetadata;
+                            oldMetadata: (nullable NSDictionary<NSString *, id> *)oldMetadata;
 
 // Called from COBranch
 
@@ -80,8 +82,10 @@
                        oldHeadRevisionUUID: (ETUUID *)oldHead
                                   ofBranch: (COBranch *)aBranch;
 - (void)recordBranchSetMetadata: (COBranch *)aBranch
-                    oldMetadata: (id)oldMetadata;
+                    oldMetadata: (nullable NSDictionary<NSString *, id> *)oldMetadata;
 - (void)recordBranchDeletion: (COBranch *)aBranch;
 - (void)recordBranchUndeletion: (COBranch *)aBranch;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COEndOfUndoTrackPlaceholderNode.h
+++ b/Undo/COEndOfUndoTrackPlaceholderNode.h
@@ -7,8 +7,13 @@
 
 #import <CoreObject/CoreObject.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface COEndOfUndoTrackPlaceholderNode : NSObject <COTrackNode>
 
 + (COEndOfUndoTrackPlaceholderNode *)sharedInstance;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COTrack.h
+++ b/Undo/COTrack.h
@@ -12,6 +12,8 @@
 @class COObject, COEditingContext, CORevision;
 @protocol COTrackNode;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** 
  * @group Undo
  * @abstract COTrack is a protocol to present changes on a timeline, 
@@ -85,7 +87,7 @@
  * the track implementation should rely on -nextNodeOnTrackFrom:backwards: as 
  * much as possible.
  */
-@property (nonatomic, readonly) NSArray *nodes;
+@property (nonatomic, readonly) NSArray<id <COTrackNode>> *nodes;
 
 /**
  * Returns the node that follows aNode on the track when back is NO, otherwise
@@ -212,10 +214,12 @@
 /**
  * Returns the parent node of this node, or nil if there is none.
  */
-@property (nonatomic, readonly) id <COTrackNode> parentNode;
+@property (nonatomic, readonly, nullable) id <COTrackNode> parentNode;
 /**
  * Returns the merge parent node of this node, or nil if there is none.
  */
-@property (nonatomic, readonly) id <COTrackNode> mergeParentNode;
+@property (nonatomic, readonly, nullable) id <COTrackNode> mergeParentNode;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COUndoTrack.h
+++ b/Undo/COUndoTrack.h
@@ -10,6 +10,8 @@
 
 @class COUndoTrackStore, COUndoTrackState, COEditingContext, COCommand, COCommandGroup;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Posted when the undo track content or current command changes, this includes 
  * changes done in another process or in related local track objects (e.g. a
@@ -147,7 +149,7 @@ extern NSString *const kCOUndoTrackName;
  * For example, use this if you want to record the user's name
  * in revisions they commit using the undo track.
  */
-@property (nonatomic, readwrite, copy) NSDictionary *customRevisionMetadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *customRevisionMetadata;
 
 
 /** @taskunit Clearing and Coalescing Commands */
@@ -208,12 +210,12 @@ extern NSString *const kCOUndoTrackName;
  *
  * See also -[COCommandGroup sequenceNumber].
  */
-@property (nonatomic, readonly) NSArray *allCommands;
+@property (nonatomic, readonly) NSArray<COCommandGroup *> *allCommands;
 /**
  * Returns all commands that are children of the given node (the order is 
  * undefined).
  */
-- (NSArray *)childrenOfNode: (id <COTrackNode>)aNode;
+- (NSArray<id <COTrackNode>> *)childrenOfNode: (id <COTrackNode>)aNode;
 
 
 /** @taskunit Framework Private */
@@ -241,6 +243,8 @@ extern NSString *const kCOUndoTrackName;
  *
  * If the command has been deleted, returns nil.
  */
-- (COCommandGroup *)commandForUUID: (ETUUID *)aUUID;
+- (nullable COCommandGroup *)commandForUUID: (ETUUID *)aUUID;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COUndoTrackHistoryCompaction.h
+++ b/Undo/COUndoTrackHistoryCompaction.h
@@ -11,6 +11,8 @@
 
 @class COUndoTrack, COCommandGroup;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** 
  * @group Undo
  * @abstract A compaction strategy that targets the history located in the undo
@@ -80,6 +82,7 @@
  */
 - (instancetype)initWithUndoTrack: (COUndoTrack *)aTrack
                       upToCommand: (COCommandGroup *)aCommand NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
 
 @property (nonatomic, readonly) COUndoTrack *undoTrack;
 
@@ -105,7 +108,7 @@
  * This method is a debugging utility, it is never used when compacting the 
  * store unlike -liveRevisionUUIDs.
  */
-@property (nonatomic, readonly) NSDictionary *deadRevisionUUIDs;
+@property (nonatomic, readonly) NSDictionary<ETUUID *, ETUUID *> *deadRevisionUUIDs;
 /**
  * The revisions sets to be kept when compacting the history, organized by 
  * persistent root UUID.
@@ -113,7 +116,7 @@
  * These revisions can include dead revisions in their range, see 
  * -deadRevisionUUIDs.
  */
-@property (nonatomic, readonly) NSDictionary *liveRevisionUUIDs;
+@property (nonatomic, readonly) NSDictionary<ETUUID *, ETUUID *> *liveRevisionUUIDs;
 
 /**
  * Returns the dead revisions per persistent root. 
@@ -121,6 +124,8 @@
  * This method is similar to -liveRevisionUUIDsForPersistentRootUUIDs:, but is
  * only available for debugging purpose.
  */
-- (NSSet *)deadRevisionUUIDsForPersistentRootUUIDs: (NSArray *)persistentRootUUIDs;
+- (NSSet<ETUUID *> *)deadRevisionUUIDsForPersistentRootUUIDs: (NSArray<ETUUID *> *)persistentRootUUIDs;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COUndoTrackHistoryCompaction.m
+++ b/Undo/COUndoTrackHistoryCompaction.m
@@ -65,10 +65,15 @@
     return self;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+
 - (instancetype)init
 {
     return [self initWithUndoTrack: nil upToCommand: nil];
 }
+
+#pragma clang diagnostic pop
 
 /**
  * Since COUndoTrackStore is almost entirely thread-safe, we could relatively

--- a/Undo/COUndoTrackStore+Private.h
+++ b/Undo/COUndoTrackStore+Private.h
@@ -11,6 +11,8 @@
 @class FMDatabase;
 @class ETUUID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString *const COUndoTrackStoreTrackDidChangeNotification;
 
 // User info keys for COUndoTrackStoreTrackDidChangeNotification
@@ -31,9 +33,9 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
 @interface COUndoTrackSerializedCommand : NSObject
 
 @property (nonatomic, readwrite, strong) id JSONData;
-@property (nonatomic, readwrite, copy) NSDictionary *metadata;
+@property (nonatomic, readwrite, copy, nullable) NSDictionary<NSString *, id> *metadata;
 @property (nonatomic, readwrite, copy) ETUUID *UUID;
-@property (nonatomic, readwrite, copy) ETUUID *parentUUID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *parentUUID;
 @property (nonatomic, readwrite, copy) NSString *trackName;
 @property (nonatomic, readwrite, copy) NSDate *timestamp;
 @property (nonatomic, readwrite, assign) int64_t sequenceNumber;
@@ -44,8 +46,8 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
 @interface COUndoTrackState : NSObject <NSCopying>
 
 @property (nonatomic, readwrite, copy) NSString *trackName;
-@property (nonatomic, readwrite, copy) ETUUID *headCommandUUID;
-@property (nonatomic, readwrite, copy) ETUUID *currentCommandUUID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *headCommandUUID;
+@property (nonatomic, readwrite, copy, nullable) ETUUID *currentCommandUUID;
 /** 
  * Reports whether a history compaction is underway for this track.
  *
@@ -114,7 +116,7 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
  * Once a track persistent state is saved with -setStateForTrackName:, the
  * track appears in the returned array until -removeTrackWithName: is called.
  */
-@property (nonatomic, readonly) NSArray *trackNames;
+@property (nonatomic, readonly) NSArray<NSString *> *trackNames;
 
 /**
  * Returns the current track names that match a pattern built with '*'.
@@ -123,14 +125,14 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
  *
  * See COPatternUndoTrack which uses this method to discover its child tracks.
  */
-- (NSArray *)trackNamesMatchingGlobPattern: (NSString *)aPattern;
+- (NSArray<NSString *> *)trackNamesMatchingGlobPattern: (NSString *)aPattern;
 /**
  * Returns the persistent state describing a track.
  *
  * When no persistent state exists in the dabase, returns nil. This means the 
  * track has never saved or has been deleted.
  */
-- (COUndoTrackState *)stateForTrackName: (NSString *)aName;
+- (nullable COUndoTrackState *)stateForTrackName: (NSString *)aName;
 /**
  * Updates the persistent state describing a track.
  *
@@ -164,7 +166,7 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
  *
  * If the UUID corresponds to a deleted command, returns nil.
  */
-- (COUndoTrackSerializedCommand *)commandForUUID: (ETUUID *)aUUID;
+- (nullable COUndoTrackSerializedCommand *)commandForUUID: (ETUUID *)aUUID;
 /**
  * Returns UUIDs for all the commands on a given track.
  *
@@ -172,7 +174,7 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
  *
  * See -markCommandsAsDeletedForUUIDs:.
  */
-- (NSArray *)allCommandUUIDsOnTrackWithName: (NSString *)aName;
+- (NSArray<ETUUID *> *)allCommandUUIDsOnTrackWithName: (NSString *)aName;
 
 
 /** @taskunit History Compaction Integration */
@@ -191,7 +193,7 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
  * To run it in the main queue, while a transaction initiated with 
  * -beginTransaction is underway will result in a deadlock.
  */
-- (void)markCommandsAsDeletedForUUIDs: (NSArray *)UUIDs;
+- (void)markCommandsAsDeletedForUUIDs: (NSArray<ETUUID *> *)UUIDs;
 /**
  * Erases commands marked as deleted permanently.
  *
@@ -222,7 +224,7 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
 /**
  * See -[COSQLiteStore pageStatistics].
  */
-@property (nonatomic, readonly) NSDictionary *pageStatistics;
+@property (nonatomic, readonly) NSDictionary<NSString *, NSNumber *> *pageStatistics;
 
 
 /** @task Glob Pattern Matching */
@@ -236,3 +238,5 @@ extern NSString *const COUndoTrackStoreTrackCompacted;
 - (BOOL)string: (NSString *)aString matchesGlobPattern: (NSString *)aPattern;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COUndoTrackStore.h
+++ b/Undo/COUndoTrackStore.h
@@ -12,6 +12,8 @@
 @class FMDatabase;
 @class ETUUID;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * @group Undo
  * @abstract A specialized store to persist undo tracks.
@@ -71,7 +73,7 @@
  * raises a NSInvalidArgumentException.
  */
 - (instancetype)initWithURL: (NSURL *)aURL NS_DESIGNATED_INITIALIZER;
-
+- (instancetype)init NS_UNAVAILABLE;
 
 /** @taskunit Basic Properties */
 
@@ -84,3 +86,5 @@
 @property (nonatomic, readonly) NSURL *URL;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Undo/COUndoTrackStore.m
+++ b/Undo/COUndoTrackStore.m
@@ -185,10 +185,15 @@ NSString *const COUndoTrackStoreTrackCompacted = @"COUndoTrackStoreTrackCompacte
     return self;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+
 - (instancetype)init
 {
     return [self initWithURL: nil];
 }
+
+#pragma clang diagnostic pop
 
 - (void)dealloc
 {

--- a/Utilities/COCommitDescriptor.h
+++ b/Utilities/COCommitDescriptor.h
@@ -8,6 +8,8 @@
 #import <Foundation/Foundation.h>
 #import <EtoileFoundation/EtoileFoundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** 
  * @group Utilities
  * @abstract A commit descriptor represents transient and persistent revision 
@@ -148,7 +150,8 @@
  *
  * For a nil argument, raises a NSInvalidArgumentException.
  */
-+ (COCommitDescriptor *)registeredDescriptorForIdentifier: (NSString *)anIdentifier;
++ (nullable COCommitDescriptor *)registeredDescriptorForIdentifier: (NSString *)anIdentifier;
+- (instancetype)init NS_UNAVAILABLE;
 
 
 /** @taskunit Persistent Metadata */
@@ -274,13 +277,13 @@
  *
  * See also -shortDescription.
  */
-- (NSString *)localizedShortDescriptionWithArguments: (NSArray *)args;
+- (NSString *)localizedShortDescriptionWithArguments: (NSArray<NSString *> *)args;
 /**
  * Looks up the commit descriptor from the metadata with 
  * kCOCommitMetadataIdentifier, and returns a localized short description built
  * by this descriptor with commit related metadata.
  */
-+ (NSString *)localizedShortDescriptionFromMetadata: (NSDictionary *)metadata;
++ (NSString *)localizedShortDescriptionFromMetadata: (NSDictionary<NSString *, id> *)metadata;
 
 @end
 
@@ -349,3 +352,5 @@ extern NSString *const kCOCommitMetadataUndoType;
  * The value is a NSNumber boolean.
  */
 extern NSString *const kCOCommitMetadataUndoInitialBaseInversed;
+
+NS_ASSUME_NONNULL_END

--- a/Utilities/CODateSerialization.h
+++ b/Utilities/CODateSerialization.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Returns an NSNumber wrapping a long long value for the Java timestamp
  * nearest to the given NSDate. A Java timestamp is in milliseconds since
@@ -14,7 +16,7 @@
  *
  * Throws an excepetion if given nil.
  */
-NSNumber *CODateToJavaTimestamp(NSDate *date);
+NSNumber *CODateToJavaTimestamp(NSDate *_Nullable date);
 
 /**
  * Converts the given NSNumber containing a Java timestamp to an NSDate. 
@@ -22,4 +24,6 @@ NSNumber *CODateToJavaTimestamp(NSDate *date);
  *
  * Throws an excepetion if given nil.
  */
-NSDate *CODateFromJavaTimestamp(NSNumber *date);
+NSDate *CODateFromJavaTimestamp(NSNumber *_Nullable date);
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
To improve Swift compatibility, I added annotations to headers in Store, Undo and Localization directories. 

The nullability annotations are based on returned value and argument assertion checks in the implementation files.

I also renamed _replcatedBranch_ to _replicatedBranch_ for Synchronization related code. Since existing mirrored branches have the wrong name, I expect this change to cause previously mirrored branch to be lost for CoreObject demo apps. I don't know whether it's an issue or not. I can remove the change or push it back to later if needed.