### PR TITLE
Make COUndoTrack usable without COEditingContext

### DIFF
--- a/Benchmark/TestHistoryNavigationPerformance.m
+++ b/Benchmark/TestHistoryNavigationPerformance.m
@@ -68,7 +68,7 @@
 - (void)testGoToOldestAndNewestNodesInHistory
 {
     COUndoTrack *track = [COUndoTrack trackForName: @"TestHistoryNavigationPerformance"
-                                withEditingContext: ctx];
+                                withContext: ctx];
 
     NSDate *startDate = [NSDate date];
     NSArray *proots = [self commitPersistentRootsWithUndoTrack: track
@@ -130,7 +130,7 @@
 - (void)testGoToFirstCommitNodeToReloadManyDeletedPersistentRoots
 {
     COUndoTrack *track = [COUndoTrack trackForName: @"TestHistoryNavigationPerformance"
-                                withEditingContext: ctx];
+                                withContext: ctx];
 
     NSDate *startDate = [NSDate date];
     NSArray *proots = [self commitPersistentRootsWithUndoTrack: track
@@ -164,7 +164,7 @@
 
     COEditingContext *ctx2 = [self newContext];
     COUndoTrack *track2 = [COUndoTrack trackForName: @"TestHistoryNavigationPerformance"
-                                 withEditingContext: ctx2];
+                                 withContext: ctx2];
 
     // Destroy the context to prevent it to catch any distributed notifications
     ctx = nil;
@@ -234,7 +234,7 @@
 - (void)testGoToOldestAndNewestNodesInHistoryWithManyPropertiesPerEntity
 {
     COUndoTrack *track = [COUndoTrack trackForName: @"TestHistoryNavigationPerformance"
-                                withEditingContext: ctx];
+                                withContext: ctx];
 
     NSDate *startDate = [NSDate date];
     NSArray *proots = [self commitPersistentRootsWithUndoTrack: track

--- a/Core/COBranch.m
+++ b/Core/COBranch.m
@@ -883,9 +883,10 @@ NSString *const kCOBranchLabel = @"COBranchLabel";
 - (COMergeInfo *)mergeInfoForMergingBranch: (COBranch *)aBranch
 {
     NILARG_EXCEPTION_TEST(aBranch);
-    ETUUID *lca = [self.editingContext commonAncestorForCommit: aBranch.currentRevision.UUID
-                                                     andCommit: self.currentRevision.UUID
-                                                persistentRoot: self.persistentRoot.UUID];
+    ETUUID *lca = COCommonAncestorRevisionUUIDs(aBranch.currentRevision.UUID,
+                                                self.currentRevision.UUID,
+                                                self.persistentRoot.UUID,
+                                                self.editingContext);
     id <COItemGraph> baseGraph = [self.store itemGraphForRevisionUUID: lca
                                                        persistentRoot: self.persistentRoot.UUID];
 
@@ -898,9 +899,10 @@ NSString *const kCOBranchLabel = @"COBranchLabel";
 - (COMergeInfo *)mergeInfoForMergingRevision: (CORevision *)aRevision
 {
     NILARG_EXCEPTION_TEST(aRevision);
-    ETUUID *lca = [self.editingContext commonAncestorForCommit: aRevision.UUID
-                                                     andCommit: self.currentRevision.UUID
-                                                persistentRoot: self.persistentRoot.UUID];
+    ETUUID *lca = COCommonAncestorRevisionUUIDs(aRevision.UUID,
+                                                self.currentRevision.UUID,
+                                                self.persistentRoot.UUID,
+                                                self.editingContext);
     id <COItemGraph> baseGraph = [self.store itemGraphForRevisionUUID: lca
                                                        persistentRoot: self.persistentRoot.UUID];
     id <COItemGraph> mergeGraph = [self.store itemGraphForRevisionUUID: aRevision.UUID

--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -8,9 +8,10 @@
 #import <Foundation/Foundation.h>
 #import <EtoileFoundation/EtoileFoundation.h>
 #import <CoreObject/COPersistentObjectContext.h>
+#import <CoreObject/COUndoTrack.h>
 
 @class COSQLiteStore, COEditingContext, COPersistentRoot, COBranch, COObjectGraphContext, COObject;
-@class COUndoTrackStore, COUndoTrack, COCommandGroup;
+@class COUndoTrackStore, COCommandGroup;
 @class COCrossPersistentRootDeadRelationshipCache, CORevisionCache;
 @class COError;
 
@@ -151,7 +152,7 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior)
  * Branch undo/redo can be used to inspect and navigate a single persistent 
  * root history (e.g. in a timeline UI presenting a document history). 
  */
-@interface COEditingContext : NSObject <COPersistentObjectContext>
+@interface COEditingContext : NSObject <COPersistentObjectContext, COUndoTrackContext>
 {
 @private
     COSQLiteStore *_store;
@@ -508,6 +509,23 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior)
  * See also -[COPersistentObjectContext editingContext].
  */
 @property (nonatomic, readonly) COEditingContext *editingContext;
+
+
+/** @taskunit Framework Private */
+
+
+/**
+ * Applies a command to the editing context (on redoing a change).
+ */
+- (void)applyCommand: (COCommand *)command;
+/**
+ * Applies a command to a store transaction (on undoing change), while
+ * leveraging the editing context state.
+ */
+- (void)applyCommand: (COCommand *)command
+  toStoreTransaction: (COStoreTransaction *)txn
+withRevisionMetadata: (nullable NSDictionary<NSString *, id> *)metadata;
+
 
 @end
 

--- a/Core/COEditingContext.h
+++ b/Core/COEditingContext.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <EtoileFoundation/EtoileFoundation.h>
 #import <CoreObject/COPersistentObjectContext.h>
+#import <CoreObject/COLeastCommonAncestor.h>
 #import <CoreObject/COUndoTrack.h>
 
 @class COSQLiteStore, COEditingContext, COPersistentRoot, COBranch, COObjectGraphContext, COObject;
@@ -152,7 +153,7 @@ typedef NS_ENUM(NSUInteger, COEditingContextUnloadingBehavior)
  * Branch undo/redo can be used to inspect and navigate a single persistent 
  * root history (e.g. in a timeline UI presenting a document history). 
  */
-@interface COEditingContext : NSObject <COPersistentObjectContext, COUndoTrackContext>
+@interface COEditingContext : NSObject <COPersistentObjectContext, COParentRevisionProvider, COUndoTrackContext>
 {
 @private
     COSQLiteStore *_store;

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -1034,11 +1034,16 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
                                 persistentRootUUID: aPersistentRoot];
 }
 
-- (COParentRevisionUUIDs)parentRevisionUUIDsForRevisionUUID:(ETUUID *)aRevisionUUID
-                                         persistentRootUUID:(ETUUID *)aPersistentRoot {
+- (ETUUID *)parentRevisionUUIDForRevisionUUID: (ETUUID *)aRevisionUUID
+                      mergeParentRevisionUUID: (ETUUID **)aMergeParentRevisionUUID
+                           persistentRootUUID: (ETUUID *)aPersistentRoot
+{
     CORevision *rev = [self revisionForRevisionUUID: aRevisionUUID
                                  persistentRootUUID: aPersistentRoot];
-    return (COParentRevisionUUIDs){ rev.parentRevision.UUID, rev.mergeParentRevision.UUID };
+    if (aMergeParentRevisionUUID != NULL) {
+        *aMergeParentRevisionUUID = rev.mergeParentRevision.UUID;
+    }
+    return rev.parentRevision.UUID;
 }
 
 - (COBranch *)branchForUUID: (ETUUID *)aBranch

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -24,6 +24,7 @@
 #import "CORevisionCache.h"
 #import "COStoreTransaction.h"
 #import "CODistributedNotificationCenter.h"
+#import "COCommand.h"
 
 @implementation COEditingContext
 
@@ -1052,6 +1053,20 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
 - (void)setLastTransactionID: (int64_t)lastTransactionID forPersistentRootUUID: (ETUUID *)aUUID
 {
     _lastTransactionIDForPersistentRootUUID[aUUID] = @(lastTransactionID);
+}
+
+#pragma mark Undo Track Integration -
+
+- (void)applyCommand: (COCommand *)command {
+    [command applyToContext: self];
+}
+
+- (void)applyCommand: (COCommand *)command
+  toStoreTransaction: (COStoreTransaction *)txn
+withRevisionMetadata: (nullable NSDictionary<NSString *, id> *)metadata {
+    [command addToStoreTransaction: txn
+              withRevisionMetadata: metadata
+       assumingEditingContextState: self];
 }
 
 @end

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -68,7 +68,7 @@
     _deadRelationshipCache = [COCrossPersistentRootDeadRelationshipCache new];
     _undoTrackStore = anUndoTrackStore;
     _recordingUndo = YES;
-    _revisionCache = [[CORevisionCache alloc] initWithParentEditingContext: self];
+    _revisionCache = [[CORevisionCache alloc] initWithStore: store];
     _internalTransientObjectGraphContext = [[COObjectGraphContext alloc]
         initWithModelDescriptionRepository: aRepo
                       migrationDriverClass: aDriverClass];

--- a/Core/COEditingContext.m
+++ b/Core/COEditingContext.m
@@ -1034,6 +1034,13 @@ restrictedToPersistentRoots: (NSArray *)persistentRoots
                                 persistentRootUUID: aPersistentRoot];
 }
 
+- (COParentRevisionUUIDs)parentRevisionUUIDsForRevisionUUID:(ETUUID *)aRevisionUUID
+                                         persistentRootUUID:(ETUUID *)aPersistentRoot {
+    CORevision *rev = [self revisionForRevisionUUID: aRevisionUUID
+                                 persistentRootUUID: aPersistentRoot];
+    return (COParentRevisionUUIDs){ rev.parentRevision.UUID, rev.mergeParentRevision.UUID };
+}
+
 - (COBranch *)branchForUUID: (ETUUID *)aBranch
 {
     if (aBranch != nil)

--- a/Core/CORevisionCache.h
+++ b/Core/CORevisionCache.h
@@ -8,22 +8,22 @@
 #import <Foundation/Foundation.h>
 #import <EtoileFoundation/ETUUID.h>
 
-@class COEditingContext, CORevision;
+@class COSQLiteStore, CORevision;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CORevisionCache : NSObject
 {
 @private
-    COEditingContext __weak *_parentContext;
+    COSQLiteStore *_store;
     NSMutableDictionary *_revisionForRevisionID;
 }
 
 /** @taskunit Framework Private */
 
-@property (nonatomic, readonly, weak) COEditingContext *parentEditingContext;
+@property (nonatomic, readonly) COSQLiteStore *store;
 
-- (instancetype)initWithParentEditingContext: (COEditingContext *)aCtx NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithStore: (COSQLiteStore *)aStore NS_DESIGNATED_INITIALIZER;
 - (nullable CORevision *)revisionForRevisionUUID: (ETUUID *)aRevid
                               persistentRootUUID: (ETUUID *)aPersistentRoot;
 

--- a/Core/CORevisionCache.m
+++ b/Core/CORevisionCache.m
@@ -7,17 +7,17 @@
 
 #import "CORevisionCache.h"
 #import "CORevision.h"
-#import "COEditingContext.h"
+#import "COSQLiteStore.h"
 
 @implementation CORevisionCache
 
-@synthesize parentEditingContext = _parentContext;
+@synthesize store = _store;
 
-- (instancetype)initWithParentEditingContext: (COEditingContext *)aCtx
+- (instancetype)initWithStore:(COSQLiteStore *)aStore
 {
-    NILARG_EXCEPTION_TEST(aCtx);
+    NILARG_EXCEPTION_TEST(aStore);
     SUPERINIT;
-    _parentContext = aCtx;
+    _store = aStore;
     _revisionForRevisionID = [[NSMutableDictionary alloc] init];
     return self;
 }
@@ -27,7 +27,7 @@
 
 - (instancetype)init
 {
-    return [self initWithParentEditingContext: nil];
+    return [self initWithStore: nil];
 }
 
 #pragma clang diagnostic pop
@@ -35,15 +35,13 @@
 - (CORevision *)revisionForRevisionUUID: (ETUUID *)aRevid
                      persistentRootUUID: (ETUUID *)aPersistentRoot
 {
-    ETAssert(_parentContext != nil);
     CORevision *cached = _revisionForRevisionID[aRevid];
 
     if (cached == nil)
     {
-        COSQLiteStore *store = _parentContext.store;
-        ETAssert(store != nil);
-        CORevisionInfo *info = [store revisionInfoForRevisionUUID: aRevid
-                                               persistentRootUUID: aPersistentRoot];
+        ETAssert(_store != nil);
+        CORevisionInfo *info = [_store revisionInfoForRevisionUUID: aRevid
+                                                persistentRootUUID: aPersistentRoot];
 
         if (info == nil)
             return nil;

--- a/Debugging/CORevision+Graphviz.m
+++ b/Debugging/CORevision+Graphviz.m
@@ -10,8 +10,8 @@
 
 - (void)show
 {
-    [[[self cache].parentEditingContext.store itemGraphForRevisionUUID: self.UUID
-                                                        persistentRoot: self.persistentRootUUID] showGraph];
+    [[[self cache].store itemGraphForRevisionUUID: self.UUID
+                                   persistentRoot: self.persistentRootUUID] showGraph];
 }
 
 @end

--- a/Diff/CODiffManager.h
+++ b/Diff/CODiffManager.h
@@ -8,6 +8,8 @@
 #import <CoreObject/COItemGraph.h>
 #import <EtoileFoundation/EtoileFoundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol CODiffAlgorithm <NSObject>
 
 + (instancetype)diffItemUUIDs: (NSArray *)uuids
@@ -53,6 +55,10 @@
                    withItemGraph: (id <COItemGraph>)b
       modelDescriptionRepository: (ETModelDescriptionRepository *)aRepository
                 sourceIdentifier: (id)aSource;
++ (CODiffManager *)diffItemGraph: (id <COItemGraph>)a
+                   withItemGraph: (id <COItemGraph>)b
+                algorithmClasses: (NSDictionary<NSString *, Class> *)algorithmClasses
+                sourceIdentifier: (id)aSource;
 - (CODiffManager *)diffByMergingWithDiff: (CODiffManager *)otherDiff;
 
 
@@ -89,3 +95,5 @@
 - (void)resolveConflictsFavoringSourceIdentifier: (id)aSource;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Diff/CODiffManager.m
+++ b/Diff/CODiffManager.m
@@ -129,13 +129,15 @@
         ETAssert(itemB != nil);
         [self checkItem: itemA hasSameEntityNameAsItem: itemB];
 
-        Class diffClass = algorithmClasses[itemB.entityName];
-        NSMutableArray *items = partitionedItemUUIDs[NSStringFromClass(diffClass)];
+        Class customDiffClass = algorithmClasses[itemB.entityName];
+        NSString *diffClass =
+            NSStringFromClass(customDiffClass != nil ? customDiffClass : [COItemGraphDiff class]);
+        NSMutableArray *items = partitionedItemUUIDs[diffClass];
     
         if (items == nil)
         {
             items = [NSMutableArray new];
-            partitionedItemUUIDs[NSStringFromClass(diffClass)] = items;
+            partitionedItemUUIDs[diffClass] = items;
         }
         [items addObject: uuid];
     }

--- a/Diff/CODiffManager.m
+++ b/Diff/CODiffManager.m
@@ -115,6 +115,61 @@
     return result;
 }
 
++ (NSDictionary *)itemUUIDsPartitionedByDiffAlgorithmNameWithFirstItemGraph: (id <COItemGraph>)a
+                                                            secondItemGraph: (id <COItemGraph>)b
+                                                           algorithmClasses: (NSDictionary<NSString *, Class> *)algorithmClasses
+{
+    NSMutableDictionary *partitionedItemUUIDs = [NSMutableDictionary new];
+
+    for (ETUUID *uuid in b.itemUUIDs)
+    {
+        COItem *itemA = [a itemForUUID: uuid]; // may be nil if the item was inserted in b
+        COItem *itemB = [b itemForUUID: uuid];
+
+        ETAssert(itemB != nil);
+        [self checkItem: itemA hasSameEntityNameAsItem: itemB];
+
+        Class diffClass = algorithmClasses[itemB.entityName];
+        NSMutableArray *items = partitionedItemUUIDs[NSStringFromClass(diffClass)];
+    
+        if (items == nil)
+        {
+            items = [NSMutableArray new];
+            partitionedItemUUIDs[NSStringFromClass(diffClass)] = items;
+        }
+        [items addObject: uuid];
+    }
+
+    return partitionedItemUUIDs;
+}
+
++ (CODiffManager *)diffItemGraph: (id <COItemGraph>)a
+                   withItemGraph: (id <COItemGraph>)b
+                algorithmClasses: (NSDictionary<NSString *, Class> *)algorithmClasses
+                sourceIdentifier: (id)aSource
+{
+    NSDictionary *partitionedItemUUIDs =
+        [self itemUUIDsPartitionedByDiffAlgorithmNameWithFirstItemGraph: a
+                                                        secondItemGraph: b
+                                                       algorithmClasses: algorithmClasses];
+
+    NSMutableDictionary *subDiffs = [NSMutableDictionary new];
+    for (NSString *algorithmName in partitionedItemUUIDs)
+    {
+        NSArray *itemUUIDs = partitionedItemUUIDs[algorithmName];
+        Class cls = NSClassFromString(algorithmName);
+        id <CODiffAlgorithm> diff = [cls diffItemUUIDs: itemUUIDs
+                                             fromGraph: a
+                                               toGraph: b
+                                      sourceIdentifier: aSource];
+        subDiffs[algorithmName] = diff;
+    }
+
+    CODiffManager *result = [[CODiffManager alloc] init];
+    result.subDiffsByAlgorithmName = subDiffs;
+    return result;
+}
+
 - (instancetype)init
 {
     SUPERINIT;

--- a/Diff/COLeastCommonAncestor.h
+++ b/Diff/COLeastCommonAncestor.h
@@ -6,23 +6,35 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <CoreObject/COEditingContext.h>
+#import <EtoileFoundation/ETUUID.h>
 
-@class ETUUID;
+NS_ASSUME_NONNULL_BEGIN
 
-@interface COEditingContext (CommonAncestor)
+typedef struct
+{
+    ETUUID *_Nullable parent;
+    ETUUID *_Nullable mergeParent;
+} COParentRevisionUUIDs;
 
-- (ETUUID *)commonAncestorForCommit: (ETUUID *)commitA
-                          andCommit: (ETUUID *)commitB
-                     persistentRoot: (ETUUID *)persistentRoot;
-- (BOOL)       isRevision: (ETUUID *)commitA
-equalToOrParentOfRevision: (ETUUID *)commitB
-           persistentRoot: (ETUUID *)persistentRoot;
-/**
- * As a sepecial case if [start isEqual: end] returns the empty array
- */
-- (NSArray *)revisionUUIDsFromRevisionUUIDExclusive: (ETUUID *)start
-                            toRevisionUUIDInclusive: (ETUUID *)end
-                                     persistentRoot: (ETUUID *)persistentRoot;
-
+@protocol COParentRevisionProvider
+- (COParentRevisionUUIDs)parentRevisionUUIDsForRevisionUUID: (ETUUID *)aRevisionUUID
+                                         persistentRootUUID: (ETUUID *)aPersistentRoot;
 @end
+
+ETUUID *_Nullable COCommonAncestorRevisionUUIDs(ETUUID *revA, 
+                                                ETUUID *revB,
+                                                ETUUID *persistentRoot,
+                                                id <COParentRevisionProvider> provider);
+BOOL CORevisionUUIDEqualToOrParent(ETUUID *revA,
+                                   ETUUID *revB,
+                                   ETUUID *persistentRoot,
+                                   id <COParentRevisionProvider> provider);
+/**
+ * As a special case, if [start isEqual: end] returns the empty array.
+ */
+NSArray<ETUUID *> *CORevisionsUUIDsFromExclusiveToInclusive(ETUUID *start, 
+                                                            ETUUID *end,
+                                                            ETUUID *persistentRoot,
+                                                            id <COParentRevisionProvider> provider);
+
+NS_ASSUME_NONNULL_END

--- a/Diff/COLeastCommonAncestor.h
+++ b/Diff/COLeastCommonAncestor.h
@@ -10,15 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef struct
-{
-    ETUUID *_Nullable parent;
-    ETUUID *_Nullable mergeParent;
-} COParentRevisionUUIDs;
-
 @protocol COParentRevisionProvider
-- (COParentRevisionUUIDs)parentRevisionUUIDsForRevisionUUID: (ETUUID *)aRevisionUUID
-                                         persistentRootUUID: (ETUUID *)aPersistentRoot;
+- (nullable ETUUID *)parentRevisionUUIDForRevisionUUID: (ETUUID *)aRevisionUUID
+                               mergeParentRevisionUUID: (ETUUID *_Nullable*_Nullable)aMergeParentRevisionUUID
+                                    persistentRootUUID: (ETUUID *)aPersistentRoot;
 @end
 
 ETUUID *_Nullable COCommonAncestorRevisionUUIDs(ETUUID *revA, 

--- a/Diff/COLeastCommonAncestor.m
+++ b/Diff/COLeastCommonAncestor.m
@@ -6,96 +6,104 @@
  */
 
 #import "COLeastCommonAncestor.h"
-#import "COEditingContext+Private.h"
 
-@implementation COEditingContext (CommonAncestor)
-
-- (void)addUUIDAndParents: (ETUUID *)aUUID
-           persistentRoot: (ETUUID *)persistentRoot
-                    toSet: (NSMutableSet *)dest
+void COCollectParentRevisionUUIDsFromInclusiveInto(ETUUID *rev,
+                                              ETUUID *persistentRoot,
+                                              NSMutableSet *ancestorRevs,
+                                              id <COParentRevisionProvider> provider)
 {
-    if ([dest containsObject: aUUID])
+    if ([ancestorRevs containsObject: rev])
         return;
 
-    [dest addObject: aUUID];
+    [ancestorRevs addObject: rev];
 
-    CORevision *revision = [self revisionForRevisionUUID: aUUID persistentRootUUID: persistentRoot];
+    COParentRevisionUUIDs parentRevUUIDs = 
+        [provider parentRevisionUUIDsForRevisionUUID: rev
+                                  persistentRootUUID: persistentRoot];
 
-    if (revision.parentRevision != nil)
-        [self addUUIDAndParents: revision.parentRevision.UUID
-                 persistentRoot: persistentRoot
-                          toSet: dest];
-
-    if (revision.mergeParentRevision != nil)
-        [self addUUIDAndParents: revision.mergeParentRevision.UUID
-                 persistentRoot: persistentRoot
-                          toSet: dest];
+    if (parentRevUUIDs.parent != nil)
+    {
+        COCollectParentRevisionUUIDsFromInclusiveInto(parentRevUUIDs.parent,
+                                                      persistentRoot,
+                                                      ancestorRevs,
+                                                      provider);
+    }
+    if (parentRevUUIDs.mergeParent != nil)
+    {
+        COCollectParentRevisionUUIDsFromInclusiveInto(parentRevUUIDs.mergeParent,
+                                                      persistentRoot,
+                                                      ancestorRevs,
+                                                      provider);
+    }
 }
 
-- (ETUUID *)commonAncestorForCommit: (ETUUID *)commitA
-                          andCommit: (ETUUID *)commitB
-                     persistentRoot: (ETUUID *)persistentRoot
+
+ETUUID *COCommonAncestorRevisionUUIDs(ETUUID *revA,
+                                      ETUUID *revB,
+                                      ETUUID *persistentRoot,
+                                      id <COParentRevisionProvider> provider)
 {
     NSMutableSet *ancestorsOfA = [NSMutableSet set];
 
-    [self addUUIDAndParents: commitA persistentRoot: persistentRoot toSet: ancestorsOfA];
+    COCollectParentRevisionUUIDsFromInclusiveInto(revA, persistentRoot, ancestorsOfA, provider);
 
-    // Do a BFS starting at commitB until we hit a commit in ancestorsOfA
+    // Do a BFS starting at revB until we hit a commit in ancestorsOfA
     // TODO: Check whether this makes sense
 
-    NSMutableArray *siblingsArray = [NSMutableArray arrayWithObject: commitB];
+    NSMutableArray *siblings = [NSMutableArray arrayWithObject: revB];
 
-    while (siblingsArray.count > 0)
+    while (siblings.count > 0)
     {
-        NSMutableArray *nextSiblingsArray = [NSMutableArray new];
+        NSMutableArray *nextSiblings = [NSMutableArray new];
 
-        for (ETUUID *sibling in siblingsArray)
+        for (ETUUID *sibling in siblings)
         {
             if ([ancestorsOfA containsObject: sibling])
             {
                 return sibling;
             }
+            COParentRevisionUUIDs parentRevUUIDs =
+                [provider parentRevisionUUIDsForRevisionUUID: sibling
+                                          persistentRootUUID: persistentRoot];
 
-            CORevision *revision = [self revisionForRevisionUUID: sibling
-                                              persistentRootUUID: persistentRoot];
+            if (parentRevUUIDs.parent != nil)
+                [nextSiblings addObject: parentRevUUIDs.parent];
 
-            if (revision.parentRevision != nil)
-                [nextSiblingsArray addObject: revision.parentRevision.UUID];
-
-            if (revision.mergeParentRevision != nil)
-                [nextSiblingsArray addObject: revision.mergeParentRevision.UUID];
+            if (parentRevUUIDs.mergeParent != nil)
+                [nextSiblings addObject: parentRevUUIDs.mergeParent];
         }
 
-        [siblingsArray setArray: nextSiblingsArray];
+        [siblings setArray: nextSiblings];
     }
 
     // No common ancestor
     return nil;
 }
 
-- (BOOL)       isRevision: (ETUUID *)commitA
-equalToOrParentOfRevision: (ETUUID *)commitB
-           persistentRoot: (ETUUID *)persistentRoot
+BOOL CORevisionUUIDEqualToOrParent(ETUUID *revA,
+                                   ETUUID *revB,
+                                   ETUUID *persistentRoot,
+                                   id <COParentRevisionProvider> provider)
 {
-    ETUUID *rev = commitB;
+    ETUUID *rev = revB;
     while (rev != nil)
     {
-        if ([rev isEqual: commitA])
+        if ([rev isEqual: revA])
         {
             return YES;
         }
-        rev = [self revisionForRevisionUUID: rev
-                         persistentRootUUID: persistentRoot].parentRevision.UUID;
+        rev = [provider parentRevisionUUIDsForRevisionUUID: rev
+                                        persistentRootUUID: persistentRoot].parent;
     }
     return NO;
 }
 
-- (NSArray *)revisionUUIDsFromRevisionUUIDExclusive: (ETUUID *)start
-                            toRevisionUUIDInclusive: (ETUUID *)end
-                                     persistentRoot: (ETUUID *)persistentRoot
+NSArray *CORevisionsUUIDsFromExclusiveToInclusive(ETUUID *start,
+                                                  ETUUID *end,
+                                                  ETUUID *persistentRoot,
+                                                  id <COParentRevisionProvider> provider)
 {
     NSMutableArray *result = [[NSMutableArray alloc] init];
-
     ETUUID *rev = end;
     while (rev != nil)
     {
@@ -104,10 +112,8 @@ equalToOrParentOfRevision: (ETUUID *)commitB
             return result;
         }
         [result insertObject: rev atIndex: 0];
-        rev = [self revisionForRevisionUUID: rev
-                         persistentRootUUID: persistentRoot].parentRevision.UUID;
+        rev = [provider parentRevisionUUIDsForRevisionUUID: rev
+                                        persistentRootUUID: persistentRoot].parent;
     }
     return nil;
 }
-
-@end

--- a/Diff/COLeastCommonAncestor.m
+++ b/Diff/COLeastCommonAncestor.m
@@ -17,20 +17,21 @@ void COCollectParentRevisionUUIDsFromInclusiveInto(ETUUID *rev,
 
     [ancestorRevs addObject: rev];
 
-    COParentRevisionUUIDs parentRevUUIDs = 
-        [provider parentRevisionUUIDsForRevisionUUID: rev
-                                  persistentRootUUID: persistentRoot];
+    ETUUID *mergeParentRev;
+    ETUUID *parentRev = [provider parentRevisionUUIDForRevisionUUID: rev
+                                            mergeParentRevisionUUID: &mergeParentRev
+                                                 persistentRootUUID: persistentRoot];
 
-    if (parentRevUUIDs.parent != nil)
+    if (parentRev != nil)
     {
-        COCollectParentRevisionUUIDsFromInclusiveInto(parentRevUUIDs.parent,
+        COCollectParentRevisionUUIDsFromInclusiveInto(parentRev,
                                                       persistentRoot,
                                                       ancestorRevs,
                                                       provider);
     }
-    if (parentRevUUIDs.mergeParent != nil)
+    if (mergeParentRev != nil)
     {
-        COCollectParentRevisionUUIDsFromInclusiveInto(parentRevUUIDs.mergeParent,
+        COCollectParentRevisionUUIDsFromInclusiveInto(mergeParentRev,
                                                       persistentRoot,
                                                       ancestorRevs,
                                                       provider);
@@ -62,15 +63,16 @@ ETUUID *COCommonAncestorRevisionUUIDs(ETUUID *revA,
             {
                 return sibling;
             }
-            COParentRevisionUUIDs parentRevUUIDs =
-                [provider parentRevisionUUIDsForRevisionUUID: sibling
-                                          persistentRootUUID: persistentRoot];
+            ETUUID *mergeParentRev;
+            ETUUID *parentRev = [provider parentRevisionUUIDForRevisionUUID: sibling
+                                                    mergeParentRevisionUUID: &mergeParentRev
+                                                         persistentRootUUID: persistentRoot];
 
-            if (parentRevUUIDs.parent != nil)
-                [nextSiblings addObject: parentRevUUIDs.parent];
+            if (parentRev != nil)
+                [nextSiblings addObject: parentRev];
 
-            if (parentRevUUIDs.mergeParent != nil)
-                [nextSiblings addObject: parentRevUUIDs.mergeParent];
+            if (mergeParentRev != nil)
+                [nextSiblings addObject: mergeParentRev];
         }
 
         [siblings setArray: nextSiblings];
@@ -92,8 +94,9 @@ BOOL CORevisionUUIDEqualToOrParent(ETUUID *revA,
         {
             return YES;
         }
-        rev = [provider parentRevisionUUIDsForRevisionUUID: rev
-                                        persistentRootUUID: persistentRoot].parent;
+        rev = [provider parentRevisionUUIDForRevisionUUID: rev
+                                  mergeParentRevisionUUID: NULL
+                                       persistentRootUUID: persistentRoot];
     }
     return NO;
 }
@@ -112,8 +115,9 @@ NSArray *CORevisionsUUIDsFromExclusiveToInclusive(ETUUID *start,
             return result;
         }
         [result insertObject: rev atIndex: 0];
-        rev = [provider parentRevisionUUIDsForRevisionUUID: rev
-                                        persistentRootUUID: persistentRoot].parent;
+        rev = [provider parentRevisionUUIDForRevisionUUID: rev
+                                  mergeParentRevisionUUID: NULL
+                                       persistentRootUUID: persistentRoot];
     }
     return nil;
 }

--- a/StorageDataModel/COItemGraph.h
+++ b/StorageDataModel/COItemGraph.h
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * See -[COItemGraph itemForUUID:].
  */
-- (COMutableItem *)itemForUUID: (ETUUID *)aUUID;
+- (nullable COMutableItem *)itemForUUID: (ETUUID *)aUUID;
 /**
  * See -[COItemGraph itemUUIDs].
  */

--- a/Synchronization/COSynchronizerClient.m
+++ b/Synchronization/COSynchronizerClient.m
@@ -207,9 +207,10 @@
     // Rebase [self.branch currentRevision] onto the new revisions
 
     const BOOL isCurrentRevDescendentOfServerRev =
-        [_ctx  isRevision: [revs.lastObject revisionUUID]
-equalToOrParentOfRevision: self.branch.currentRevision.UUID
-           persistentRoot: self.persistentRoot.UUID];
+            CORevisionUUIDEqualToOrParent([revs.lastObject revisionUUID],
+                                          self.branch.currentRevision.UUID,
+                                          self.persistentRoot.UUID,
+                                          _ctx);
 
     if (_lastRevisionUUIDInTransitToServer != nil
         && ![self.branch.currentRevision.UUID isEqual: _lastRevisionUUIDInTransitToServer]
@@ -305,9 +306,11 @@ equalToOrParentOfRevision: self.branch.currentRevision.UUID
 
     NSMutableArray *revs = [[NSMutableArray alloc] init];
 
-    NSArray *revUUIDs = [_ctx revisionUUIDsFromRevisionUUIDExclusive: [self lastRevisionUUIDFromServer]
-                                             toRevisionUUIDInclusive: self.branch.currentRevision.UUID
-                                                      persistentRoot: self.persistentRoot.UUID];
+    NSArray *revUUIDs = 
+        CORevisionsUUIDsFromExclusiveToInclusive([self lastRevisionUUIDFromServer],
+                                                 self.branch.currentRevision.UUID,
+                                                 self.persistentRoot.UUID,
+                                                 _ctx);
 
     for (ETUUID *revUUID in revUUIDs)
     {

--- a/Synchronization/COSynchronizerServer.m
+++ b/Synchronization/COSynchronizerServer.m
@@ -78,9 +78,10 @@
     }
     ETAssert([self.persistentRoot.store commitStoreTransaction: txn]);
 
-    if (![branch.editingContext isRevision: self.branch.currentRevision.UUID
-                 equalToOrParentOfRevision: [revs.lastObject revisionUUID]
-                            persistentRoot: self.persistentRoot.UUID])
+    if (!CORevisionUUIDEqualToOrParent(self.branch.currentRevision.UUID,
+                                       [revs.lastObject revisionUUID],
+                                       self.persistentRoot.UUID,
+                                       branch.editingContext))
     {
         // Rebase revs onto the current revisions
 
@@ -88,10 +89,10 @@
 
         ETUUID *source = [revs.lastObject revisionUUID];
         ETUUID *dest = self.branch.currentRevision.UUID;
-
-        ETUUID *lca = [self.persistentRoot.editingContext commonAncestorForCommit: source
-                                                                        andCommit: dest
-                                                                   persistentRoot: self.persistentRoot.UUID];
+        ETUUID *lca = COCommonAncestorRevisionUUIDs(source, 
+                                                    dest,
+                                                    self.persistentRoot.UUID,
+                                                    self.persistentRoot.editingContext);
 
         NSArray *rebasedRevs = [COSynchronizerUtils rebaseRevision: source
                                                       ontoRevision: dest
@@ -173,9 +174,10 @@
     NSMutableArray *revs = [[NSMutableArray alloc] init];
 
     ETAssert(branch.editingContext != nil);
-    NSArray *revUUIDs = [branch.editingContext revisionUUIDsFromRevisionUUIDExclusive: lastConfirmedForClient
-                                                              toRevisionUUIDInclusive: self.branch.currentRevision.UUID
-                                                                       persistentRoot: self.persistentRoot.UUID];
+    NSArray *revUUIDs = CORevisionsUUIDsFromExclusiveToInclusive(lastConfirmedForClient,
+                                                                 self.branch.currentRevision.UUID,
+                                                                 self.persistentRoot.UUID,
+                                                                 branch.editingContext);
 
     if (revUUIDs == nil)
     {

--- a/Synchronization/COSynchronizerUtils.m
+++ b/Synchronization/COSynchronizerUtils.m
@@ -79,9 +79,8 @@
     ETAssert(lca != nil);
 
     // Gather the revisions to rebase (between 'lca', exclusive, and 'source', inclusive)
-    NSArray *sourceRevs = [ctx revisionUUIDsFromRevisionUUIDExclusive: lca
-                                              toRevisionUUIDInclusive: source
-                                                       persistentRoot: persistentRoot];
+    NSArray *sourceRevs =
+        CORevisionsUUIDsFromExclusiveToInclusive(lca, source, persistentRoot, ctx);
     ETAssert(sourceRevs != nil);
     ETAssert(sourceRevs.count > 0);
 

--- a/TODO.md
+++ b/TODO.md
@@ -336,7 +336,7 @@ the following situations at least:
 
 - COUndoTrack
 
-  - Doesn’t work: [[COUndoTrack trackForPattern: @"org.etoile.projectdemo*" withEditingContext: nil] clear];
+  - Doesn’t work: [[COUndoTrack trackForPattern: @"org.etoile.projectdemo*" withContext: nil] clear];
 
   - Perhaps have different commands for a regular commit and a revert.
     It's probably confusing or dangerous that undoing a revert can cause a selective undo (as it can now),
@@ -353,8 +353,8 @@ the following situations at least:
 
   - e.g:
   
-        a = [COUndoTrack trackForName: @"test" withEditingContext: ctx]
-        b = [COUndoTrack trackForName: @"test" withEditingContext: ctx]
+        a = [COUndoTrack trackForName: @"test" withContext: ctx]
+        b = [COUndoTrack trackForName: @"test" withContext: ctx]
         ...
         [ctx commitWithUndoTrack: a]
 

--- a/Tests/Core/TestBranch.m
+++ b/Tests/Core/TestBranch.m
@@ -43,7 +43,7 @@
 
     UKFalse(altBranch.objectGraphContext.hasChanges);
 
-    _testTrack = [COUndoTrack trackForName: @"test" withEditingContext: ctx];
+    _testTrack = [COUndoTrack trackForName: @"test" withContext: ctx];
     [_testTrack clear];
 
     return self;

--- a/Tests/Core/TestNotifications.m
+++ b/Tests/Core/TestNotifications.m
@@ -40,7 +40,7 @@
 
 - (void)testPersistentRootNotificationOnUndoLocal
 {
-    COUndoTrack *track = [COUndoTrack trackForName: @"test" withEditingContext: ctx];
+    COUndoTrack *track = [COUndoTrack trackForName: @"test" withContext: ctx];
     [track clear];
 
     [persistentRoot1.rootObject setLabel: @"world"];

--- a/Tests/Extras/Model/TestAttributedStringHistory.m
+++ b/Tests/Extras/Model/TestAttributedStringHistory.m
@@ -24,7 +24,7 @@
     // This test was triggering some random failures; so run it 10 times
     for (NSUInteger iters = 0; iters < 10; iters++)
     {
-        COUndoTrack *track = [COUndoTrack trackForName: @"test" withEditingContext: ctx];
+        COUndoTrack *track = [COUndoTrack trackForName: @"test" withContext: ctx];
         [track clear];
 
         COPersistentRoot *proot = [ctx insertNewPersistentRootWithEntityName: @"COAttributedString"];

--- a/Tests/Undo/TestCustomTrack.m
+++ b/Tests/Undo/TestCustomTrack.m
@@ -26,8 +26,8 @@
 
     ctx.unloadingBehavior = COEditingContextUnloadingBehaviorManual;
 
-    _testTrack = [COUndoTrack trackForName: @"test" withEditingContext: ctx];
-    _setupTrack = [COUndoTrack trackForName: @"setup" withEditingContext: ctx];
+    _testTrack = [COUndoTrack trackForName: @"test" withContext: ctx];
+    _setupTrack = [COUndoTrack trackForName: @"setup" withContext: ctx];
     [_testTrack clear];
     [_setupTrack clear];
 

--- a/Tests/Undo/TestHistoryTrack.m
+++ b/Tests/Undo/TestHistoryTrack.m
@@ -25,9 +25,9 @@
 {
     SUPERINIT;
 
-    _workspaceTrack = [COUndoTrack trackForName: @"workspace" withEditingContext: ctx];
-    _doc1Track = [COUndoTrack trackForName: @"doc1" withEditingContext: ctx];
-    _doc2Track = [COUndoTrack trackForName: @"doc2" withEditingContext: ctx];
+    _workspaceTrack = [COUndoTrack trackForName: @"workspace" withContext: ctx];
+    _doc1Track = [COUndoTrack trackForName: @"doc1" withContext: ctx];
+    _doc2Track = [COUndoTrack trackForName: @"doc2" withContext: ctx];
 
     [_workspaceTrack clear];
     [_doc1Track clear];

--- a/Tests/Undo/TestUndo.m
+++ b/Tests/Undo/TestUndo.m
@@ -33,10 +33,10 @@
 {
     SUPERINIT;
 
-    _testTrack = [COUndoTrack trackForName: @"test" withEditingContext: ctx];
-    _setupTrack = [COUndoTrack trackForName: @"setup" withEditingContext: ctx];
-    _rootEditTrack = [COUndoTrack trackForName: @"rootEdit" withEditingContext: ctx];
-    _childEditTrack = [COUndoTrack trackForName: @"childEdit" withEditingContext: ctx];
+    _testTrack = [COUndoTrack trackForName: @"test" withContext: ctx];
+    _setupTrack = [COUndoTrack trackForName: @"setup" withContext: ctx];
+    _rootEditTrack = [COUndoTrack trackForName: @"rootEdit" withContext: ctx];
+    _childEditTrack = [COUndoTrack trackForName: @"childEdit" withContext: ctx];
 
     [_testTrack clear];
     [_setupTrack clear];
@@ -511,11 +511,11 @@
     [ctx commitWithUndoTrack: _setupTrack];
 
     COUndoTrack *workspaceTrack = [COUndoTrack trackForPattern: @"workspace.*"
-                                            withEditingContext: ctx];
+                                            withContext: ctx];
     COUndoTrack *workspaceDoc1Track = [COUndoTrack trackForName: @"workspace.doc1"
-                                             withEditingContext: ctx];
+                                             withContext: ctx];
     COUndoTrack *workspaceDoc2Track = [COUndoTrack trackForName: @"workspace.doc2"
-                                             withEditingContext: ctx];
+                                             withContext: ctx];
     [workspaceTrack clear];
 
     // doc1 commits
@@ -829,7 +829,7 @@
 
 - (COUndoTrack *)trackWithEditingContext: (COEditingContext *)aContext
 {
-    return [[self class] trackForName: self.name withEditingContext: aContext];
+    return [[self class] trackForName: self.name withContext: aContext];
 }
 
 @end

--- a/Tests/Undo/TestUndoStackFailedNavigation.m
+++ b/Tests/Undo/TestUndoStackFailedNavigation.m
@@ -27,7 +27,7 @@
 - (instancetype)init
 {
     SUPERINIT;
-    track = [COUndoTrack trackForName: @"test" withEditingContext: ctx];
+    track = [COUndoTrack trackForName: @"test" withContext: ctx];
     [track clear];
 
     // set root to "0" ---- not on undo track

--- a/Tests/Undo/TestUndoStackTrackProtocol.m
+++ b/Tests/Undo/TestUndoStackTrackProtocol.m
@@ -28,7 +28,7 @@
 - (instancetype)init
 {
     SUPERINIT;
-    track = [COUndoTrack trackForName: @"test" withEditingContext: ctx];
+    track = [COUndoTrack trackForName: @"test" withContext: ctx];
     [track clear];
 
     persistentRoot = [ctx insertNewPersistentRootWithEntityName: @"OutlineItem"];
@@ -170,7 +170,7 @@
 
 - (void)testEmptyTrack
 {
-    COUndoTrack *emptyTrack = [COUndoTrack trackForName: @"emptyTrack" withEditingContext: ctx];
+    COUndoTrack *emptyTrack = [COUndoTrack trackForName: @"emptyTrack" withContext: ctx];
     [emptyTrack clear];
 
     UKObjectsEqual([COEndOfUndoTrackPlaceholderNode sharedInstance], [emptyTrack currentNode]);

--- a/Tests/Undo/TestUndoTrack.m
+++ b/Tests/Undo/TestUndoTrack.m
@@ -119,21 +119,21 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
 {
     SUPERINIT;
 
-    _track = [COUndoTrack trackForName: TEST_TRACK withEditingContext: ctx];
+    _track = [COUndoTrack trackForName: TEST_TRACK withContext: ctx];
     [_track clear];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(trackDidChange:)
                                                  name: COUndoTrackDidChangeNotification
                                                object: _track];
 
-    _track2 = [COUndoTrack trackForName: TEST_TRACK_2 withEditingContext: ctx];
+    _track2 = [COUndoTrack trackForName: TEST_TRACK_2 withContext: ctx];
     [_track2 clear];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(trackDidChange:)
                                                  name: COUndoTrackDidChangeNotification
                                                object: _track2];
 
-    _patternTrack = [COUndoTrack trackForPattern: TEST_TRACK_STAR withEditingContext: ctx];
+    _patternTrack = [COUndoTrack trackForPattern: TEST_TRACK_STAR withContext: ctx];
     [_patternTrack clear];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(trackDidChange:)
@@ -178,7 +178,7 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     // Check with a second COUndoTrack
 
     COUndoTrack *secondTrackInstance = [COUndoTrack trackForName: TEST_TRACK
-                                              withEditingContext: ctx];
+                                              withContext: ctx];
     UKObjectsNotSame(_track, secondTrackInstance);
     UKObjectsEqual(A(placeholderNode, group), secondTrackInstance.nodes);
     UKObjectsEqual(group, [secondTrackInstance currentNode]);
@@ -212,7 +212,7 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     // Check with a second COUndoTrack
 
     COUndoTrack *secondTrackInstance = [COUndoTrack trackForName: TEST_TRACK
-                                              withEditingContext: ctx];
+                                              withContext: ctx];
     UKObjectsNotSame(_track, secondTrackInstance);
     UKObjectsEqual(A(placeholderNode, group1, group2), secondTrackInstance.nodes);
     UKObjectsEqual(group2, [secondTrackInstance currentNode]);
@@ -245,7 +245,7 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     // Check with a second COUndoTrack
     {
         COUndoTrack *secondTrackInstance = [COUndoTrack trackForName: TEST_TRACK
-                                                  withEditingContext: ctx];
+                                                  withContext: ctx];
         UKObjectsEqual(A(placeholderNode, group1, group2), secondTrackInstance.nodes);
         UKObjectsEqual(group1, [secondTrackInstance currentNode]);
         UKObjectsEqual(placeholderNode.UUID,
@@ -258,7 +258,7 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
 
     {
         COUndoTrack *secondTrackInstance = [COUndoTrack trackForName: TEST_TRACK
-                                                  withEditingContext: ctx];
+                                                  withContext: ctx];
         UKObjectsEqual(group2, [secondTrackInstance currentNode]);
     }
 }
@@ -397,11 +397,11 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     UKObjectsEqual(group2a, [_track2 currentNode]);
     UKObjectsEqual(group1b, [_patternTrack currentNode]);
     UKObjectsEqual(group1b,
-                   [[COUndoTrack trackForName: TEST_TRACK withEditingContext: ctx] currentNode]);
+                   [[COUndoTrack trackForName: TEST_TRACK withContext: ctx] currentNode]);
     UKObjectsEqual(group2a, [[COUndoTrack trackForName: TEST_TRACK_2
-                                    withEditingContext: ctx] currentNode]);
+                                    withContext: ctx] currentNode]);
     UKObjectsEqual(group1b, [[COUndoTrack trackForName: TEST_TRACK_STAR
-                                    withEditingContext: ctx] currentNode]);
+                                    withContext: ctx] currentNode]);
 
     [_patternTrack undo];
 
@@ -409,11 +409,11 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     UKObjectsEqual(group2a, [_track2 currentNode]);
     UKObjectsEqual(group2a, [_patternTrack currentNode]);
     UKObjectsEqual(group1a,
-                   [[COUndoTrack trackForName: TEST_TRACK withEditingContext: ctx] currentNode]);
+                   [[COUndoTrack trackForName: TEST_TRACK withContext: ctx] currentNode]);
     UKObjectsEqual(group2a, [[COUndoTrack trackForName: TEST_TRACK_2
-                                    withEditingContext: ctx] currentNode]);
+                                    withContext: ctx] currentNode]);
     UKObjectsEqual(group2a, [[COUndoTrack trackForName: TEST_TRACK_STAR
-                                    withEditingContext: ctx] currentNode]);
+                                    withContext: ctx] currentNode]);
 
     [_patternTrack undo];
 
@@ -421,11 +421,11 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     UKObjectsEqual(placeholderNode, [_track2 currentNode]);
     UKObjectsEqual(group1a, [_patternTrack currentNode]);
     UKObjectsEqual(group1a,
-                   [[COUndoTrack trackForName: TEST_TRACK withEditingContext: ctx] currentNode]);
+                   [[COUndoTrack trackForName: TEST_TRACK withContext: ctx] currentNode]);
     UKObjectsEqual(placeholderNode, [[COUndoTrack trackForName: TEST_TRACK_2
-                                            withEditingContext: ctx] currentNode]);
+                                            withContext: ctx] currentNode]);
     UKObjectsEqual(group1a, [[COUndoTrack trackForName: TEST_TRACK_STAR
-                                    withEditingContext: ctx] currentNode]);
+                                    withContext: ctx] currentNode]);
 
     [_patternTrack undo];
 
@@ -433,11 +433,11 @@ static COEndOfUndoTrackPlaceholderNode *placeholderNode = nil;
     UKObjectsEqual(placeholderNode, [_track2 currentNode]);
     UKObjectsEqual(placeholderNode, [_patternTrack currentNode]);
     UKObjectsEqual(placeholderNode,
-                   [[COUndoTrack trackForName: TEST_TRACK withEditingContext: ctx] currentNode]);
+                   [[COUndoTrack trackForName: TEST_TRACK withContext: ctx] currentNode]);
     UKObjectsEqual(placeholderNode, [[COUndoTrack trackForName: TEST_TRACK_2
-                                            withEditingContext: ctx] currentNode]);
+                                            withContext: ctx] currentNode]);
     UKObjectsEqual(placeholderNode, [[COUndoTrack trackForName: TEST_TRACK_STAR
-                                            withEditingContext: ctx] currentNode]);
+                                            withContext: ctx] currentNode]);
 }
 
 /**

--- a/Tests/Undo/TestUndoTrackHistoryCompaction.m
+++ b/Tests/Undo/TestUndoTrackHistoryCompaction.m
@@ -15,6 +15,8 @@
 
 @interface COExpectedCompaction : COUndoTrackHistoryCompaction
 
+- (instancetype)init;
+
 @property (nonatomic, readwrite, copy) NSSet *finalizablePersistentRootUUIDs;
 @property (nonatomic, readwrite, copy) NSSet *compactablePersistentRootUUIDs;
 @property (nonatomic, readwrite, copy) NSDictionary *deadRevisionUUIDs;

--- a/Tests/Undo/TestUndoTrackHistoryCompaction.m
+++ b/Tests/Undo/TestUndoTrackHistoryCompaction.m
@@ -87,7 +87,7 @@
     // NOTE: The name must not start with 'TestUndoTrack', otherwise this
     // conflicts with pattern track tests in TestUndoTrack.m.
     track = [COUndoTrack trackForName: @"TestHistoryCompaction"
-                   withEditingContext: ctx];
+                   withContext: ctx];
     [track clear];
 }
 
@@ -537,13 +537,13 @@
     // NOTE: The name must not start with 'TestUndoTrack', otherwise this
     // conflicts with pattern track tests in TestUndoTrack.m.
     track = [COUndoTrack trackForPattern: @"TestHistoryCompaction/Pattern/*"
-                      withEditingContext: ctx];
+                      withContext: ctx];
     [track clear];
     concreteTrack1 = [COUndoTrack trackForName: @"TestHistoryCompaction/Pattern/1"
-                            withEditingContext: ctx];
+                            withContext: ctx];
     [concreteTrack1 clear];
     concreteTrack2 = [COUndoTrack trackForName: @"TestHistoryCompaction/Pattern/2"
-                            withEditingContext: ctx];
+                            withContext: ctx];
     [concreteTrack2 clear];
 }
 

--- a/Tests/Undo/TestUndoUseCases.m
+++ b/Tests/Undo/TestUndoUseCases.m
@@ -27,7 +27,7 @@
 {
     SUPERINIT;
 
-    _testTrack = [COUndoTrack trackForName: @"test" withEditingContext: ctx];
+    _testTrack = [COUndoTrack trackForName: @"test" withContext: ctx];
     [_testTrack clear];
 
     return self;

--- a/Undo/COCommand.h
+++ b/Undo/COCommand.h
@@ -9,7 +9,7 @@
 #import <EtoileFoundation/ETUUID.h>
 #import <CoreObject/COTrack.h>
 
-@class COEditingContext, COUndoTrack;
+@class COEditingContext, COUndoTrack, COStoreTransaction;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Undo/COCommandSetCurrentVersionForBranch.m
+++ b/Undo/COCommandSetCurrentVersionForBranch.m
@@ -139,9 +139,10 @@ static NSString *const kCOCommandNewHeadRevisionID = @"COCommandNewHeadRevisionI
         branch.currentRevision = [aContext revisionForRevisionUUID: _newRevisionUUID
                                                 persistentRootUUID: _persistentRootUUID];
 
-        if (![aContext isRevision: _newHeadRevisionUUID
-        equalToOrParentOfRevision: _oldHeadRevisionUUID
-                   persistentRoot: _persistentRootUUID])
+        if (!CORevisionUUIDEqualToOrParent(_newHeadRevisionUUID,
+                                           _oldHeadRevisionUUID,
+                                           _persistentRootUUID,
+                                           aContext))
         {
             branch.headRevision = [aContext revisionForRevisionUUID: _newHeadRevisionUUID
                                                  persistentRootUUID: _persistentRootUUID];
@@ -217,9 +218,10 @@ static NSString *const kCOCommandNewHeadRevisionID = @"COCommandNewHeadRevisionI
     if ([branchCurrentRevisionUUID isEqual: _oldRevisionUUID] && branch.supportsRevert)
     {
         // TODO: Could be a bottleneck; migrate COLeastCommonAncestor to use the revision cache.
-        if (![aContext isRevision: _newHeadRevisionUUID
-        equalToOrParentOfRevision: _oldHeadRevisionUUID
-                   persistentRoot: _persistentRootUUID])
+        if (!CORevisionUUIDEqualToOrParent(_newHeadRevisionUUID,
+                                           _oldHeadRevisionUUID,
+                                           _persistentRootUUID,
+                                           aContext))
         {
             [txn setCurrentRevision: _newRevisionUUID
                        headRevision: _newHeadRevisionUUID

--- a/Undo/COCommandSetCurrentVersionForBranch.m
+++ b/Undo/COCommandSetCurrentVersionForBranch.m
@@ -296,15 +296,15 @@ static NSString *const kCOCommandNewHeadRevisionID = @"COCommandNewHeadRevisionI
 - (CORevision *)oldRevision
 {
     ETAssert(_parentUndoTrack != nil);
-    return [_parentUndoTrack.editingContext revisionForRevisionUUID: _oldRevisionUUID
-                                                 persistentRootUUID: _persistentRootUUID];
+    return [_parentUndoTrack.context revisionForRevisionUUID: _oldRevisionUUID
+                                          persistentRootUUID: _persistentRootUUID];
 }
 
 - (CORevision *)revision
 {
     ETAssert(_parentUndoTrack != nil);
-    return [_parentUndoTrack.editingContext revisionForRevisionUUID: _newRevisionUUID
-                                                 persistentRootUUID: _persistentRootUUID];
+    return [_parentUndoTrack.context revisionForRevisionUUID: _newRevisionUUID
+                                          persistentRootUUID: _persistentRootUUID];
 }
 
 #pragma mark -

--- a/Undo/COCommandSetCurrentVersionForBranch.m
+++ b/Undo/COCommandSetCurrentVersionForBranch.m
@@ -217,7 +217,6 @@ static NSString *const kCOCommandNewHeadRevisionID = @"COCommandNewHeadRevisionI
 
     if ([branchCurrentRevisionUUID isEqual: _oldRevisionUUID] && branch.supportsRevert)
     {
-        // TODO: Could be a bottleneck; migrate COLeastCommonAncestor to use the revision cache.
         if (!CORevisionUUIDEqualToOrParent(_newHeadRevisionUUID,
                                            _oldHeadRevisionUUID,
                                            _persistentRootUUID,

--- a/Undo/COCommandUndeletePersistentRoot.m
+++ b/Undo/COCommandUndeletePersistentRoot.m
@@ -93,8 +93,8 @@ static NSString *const kCOCommandInitialRevisionID = @"COCommandInitialRevisionI
 
 - (CORevision *)revision
 {
-    return [_parentUndoTrack.editingContext revisionForRevisionUUID: _initialRevisionID
-                                                 persistentRootUUID: _persistentRootUUID];
+    return [_parentUndoTrack.context revisionForRevisionUUID: _initialRevisionID
+                                     persistentRootUUID: _persistentRootUUID];
 }
 
 

--- a/Undo/COTrack.h
+++ b/Undo/COTrack.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * A track content can be persistent (e.g. a normal undo track or a branch) or 
  * lazily constructed (e.g. a pattern undo track, see 
- * +[COUndoTrack trackForPattern:withEditingContext:]).
+ * +[COUndoTrack trackForPattern:withContext:]).
  *
  * @section Track Node Collection 
  *


### PR DESCRIPTION
Hey Eric,

I'm resuming my work on Toukan and CoreObject today.

To give you some background about this PR… In Toukan, I have a high-level API written in Swift, that replaces COEditingContext, COPersistentRoot, COBranch, COObjectGraphContext and COObject. It's much more limited in term of features and scope. I more or less reduced the API to COEditingContext and CObjectGraphContext.

For now, I don't have support for branches or cross-persistent references, which I might reintroduce later to not. I also replaced the metamodel and relationship cache with property annotations. For example, declaring a to-many  composite relationship for a property 'children' look like this:

```swift
    @RelationshipToMany<Node, Node>(inverse: \Node.parent, isParent: true, sendsChange: false)
    var children: [Node]
```

---

In the current CoreObject version, COUndoTrack is partially tied to the Core API. With this PR, I change COUndoTrack and related classes (COCommand class hierarchy and COUndoTrackStore) to become completely independent of the Core classes (COEditingContext, COObjectGraphContext etc.), so it can be used with other high-level API such as the one I wrote in Swift for Toukan.

Here are the key changes I made in this PR:
- Made `CORevisionCache` independent of `COEditingContext`
  - when writing a replacement for the Core API, it's now possible to reuse it
  - the revision cache now depends on `COSQLiteStore`
- Make `COCommand` independent of `COEditingContext`
  - a `COUndoTrackContext` protocol has been introduced and  can be implemented to double-dispatch operations on the undo track to the right command through the context
  - `COUndoTrackContext` is declared in _COUndoTrack.h_
  - see `-applyCommand:` and `-applyCommand:toStoreTransaction:withMetadata:`
- Made `COLeastCommonAncestor` algorithms independent of `COEditingContext`
  - these methods have been turned into standalone functions that takes a parent revision provider
  - when writing a replacement for the Core API, it's now possible to reuse them
- New `-[CODiffManager diffItemWithItemGraph:algorithmClasses:sourceIdentifier:]` to support making diffs without a model description repository
  - in Toukan, model classes own their metamodel (eliminating the need to construct a standalone metamodel)
    - attributes/relationships are described with annotations attached to properties
    - annotations can be accessed at run-time through model instances