### PR TITLE
Support multiple editing contexts run in different threads and accessing the same store

### DIFF
--- a/CODistributedNotificationCenter.h
+++ b/CODistributedNotificationCenter.h
@@ -41,6 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
                name: (nullable NSNotificationName)aName 
              object: (nullable NSString *)anObject;
 /**
+ * Adds a notification handler to be run on a queue for the given selector, notification name and
+ * object identifier.
+ */
+- (id <NSObject>)addObserverForName: (nullable NSNotificationName)aName
+                             object: (nullable id)anObject
+                              queue: (nullable NSOperationQueue *)aQueue
+                         usingBlock: (void (^)(NSNotification *notification))block;
+/**
  * Removes an observer.
  */
 - (void)removeObserver: (id)observer;

--- a/CODistributedNotificationCenter.m
+++ b/CODistributedNotificationCenter.m
@@ -44,6 +44,26 @@ static CODistributedNotificationCenter *defaultCenter = nil;
 #endif
 }
 
+- (id <NSObject>)addObserverForName: (NSNotificationName)aName
+                             object: (id)anObject
+                              queue: (NSOperationQueue *)aQueue
+                         usingBlock: (void (^)(NSNotification *notification))block
+{
+#if !(SANDBOXED) && !(TARGET_OS_IPHONE)
+    return [[NSDistributedNotificationCenter defaultCenter]
+        addObserverForName: aName
+                    object: anObject
+                     queue: aQueue
+                usingBlock: block];
+#else
+    return [[NSNotificationCenter defaultCenter]
+        addObserverForName: aName
+                    object: anObject
+                     queue: aQueue
+                usingBlock: block];
+#endif
+}
+
 - (void)removeObserver: (id)observer {
 #if !(SANDBOXED) && !(TARGET_OS_IPHONE)
     [[NSDistributedNotificationCenter defaultCenter] removeObserver: observer];

--- a/Store/COSQLiteStore.h
+++ b/Store/COSQLiteStore.h
@@ -350,6 +350,7 @@ extern NSString *const COPersistentRootAttributeUsedSize;
     NSMutableDictionary *backingStoreUUIDForPersistentRootUUID_;
 
     dispatch_queue_t queue_;
+    dispatch_semaphore_t _commitLock;
     NSUInteger _maxNumberOfDeltaCommits;
 }
 

--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -1037,19 +1037,22 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
  */
 - (void)postCommitNotificationsWithUserInfo: (NSDictionary *)userInfo
 {
-    ETAssert([NSThread isMainThread]);
     ETAssert([NSPropertyListSerialization propertyList: userInfo
                                       isValidForFormat: NSPropertyListXMLFormat_v1_0]);
 
-    [[NSNotificationCenter defaultCenter] postNotificationName: COStorePersistentRootsDidChangeNotification
-                                                        object: self
-                                                      userInfo: userInfo];
+    dispatch_async(dispatch_get_main_queue(), ^()
+    {
+        [[NSNotificationCenter defaultCenter] 
+            postNotificationName: COStorePersistentRootsDidChangeNotification
+                          object: self
+                        userInfo: userInfo];
 
-    [[CODistributedNotificationCenter defaultCenter]
-        postNotificationName: COStorePersistentRootsDidChangeNotification
-                      object: [self.UUID stringValue]
-                    userInfo: userInfo
-          deliverImmediately: YES];
+        [[CODistributedNotificationCenter defaultCenter]
+            postNotificationName: COStorePersistentRootsDidChangeNotification
+                          object: [self.UUID stringValue]
+                        userInfo: userInfo
+              deliverImmediately: YES];
+    });
 }
 
 - (void)postCommitNotificationsWithTransactionIDForPersistentRootUUID: (NSDictionary *)txnIDForPersistentRoot

--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -130,6 +130,7 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
     // For GNUstep, ARC doesn't manage libdispatch objects since libobjc2 doesn't support it 
     // currently (we compile CoreObject with -DOS_OBJECT_USE_OBJC=0).
     dispatch_release(queue_);
+    dispatch_release(_commitLock);
 #endif
 }
 

--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -63,6 +63,7 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
     url_ = aURL;
     backingStores_ = [[NSMutableDictionary alloc] init];
     backingStoreUUIDForPersistentRootUUID_ = [[NSMutableDictionary alloc] init];
+    _commitLock = dispatch_semaphore_create(1);
     _maxNumberOfDeltaCommits = 50;
 
     __block BOOL ok = YES;
@@ -218,16 +219,25 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
 
 #pragma mark Transactions -
 
+- (void)beginCommit
+{
+    dispatch_semaphore_wait(_commitLock, DISPATCH_TIME_FOREVER);
+}
+
+- (void)endCommit {
+    dispatch_semaphore_signal(_commitLock);
+}
 
 - (BOOL)commitStoreTransaction: (COStoreTransaction *)aTransaction
 {
-    __block BOOL ok = YES;
-
     dispatch_assert_queue_not(queue_);
+
+    [self beginCommit];
 
     NSMutableDictionary *txnIDForPersistentRoot = [[NSMutableDictionary alloc] init];
     NSMutableArray *insertedUUIDs = [[NSMutableArray alloc] init];
     NSMutableArray *deletedUUIDs = [[NSMutableArray alloc] init];
+    __block BOOL ok = YES;
 
     dispatch_sync(queue_, ^()
     {
@@ -342,6 +352,7 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
         NSLog(@"Commit failed");
     }
 
+    [self endCommit];
     return ok;
 }
 
@@ -1029,30 +1040,41 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
     return statistics;
 }
 
-/**
- * We could put this code in a block passed to dispatch_async(dispatch_get_main_queue(), theBlock) 
- * and  call dispatch_async() in our  caller, but dispatch_get_main_queue() is only supported for 
- * macOS (not on Linux or elsewhere). In future, GNUstep GUI could create a wrapper queue 
- * around NSRunLoop and set it as _dispatch_main_q.
- */
+// Commit notifications must match the commit order against the database,
+// otherwise with multiple threads/queues committing against the same store
+// object, editing contexts could receive notifications out of order. The
+// most critical issue is incorrect transaction ID per persistent root.
+// 
+// To ensure commit notification order is correct, we must execute store
+// transaction and commit notifications in an atomic way. We can either:
+// 1) post commit notifications with the store queue
+// 2) lock the whole store commit operation
+//
+// The second option was chosen, because commit notifications are then received
+// immediately in the same queue (or thread) than the one used to commit. The
+// first option would require test code to use -wait between commits to be sure
+// editing contexts are up-to-date.
+//
+// When multiple editing contexts are created in different queues or threads,
+// commit notifications must be received with a locking mechanism around
+// editing context mutable state, to protect it  against concurrent access
+// (e.g. mutating persistent roots). The locking mechanism can be the queue
+// on which the editing context was created.
 - (void)postCommitNotificationsWithUserInfo: (NSDictionary *)userInfo
 {
     ETAssert([NSPropertyListSerialization propertyList: userInfo
                                       isValidForFormat: NSPropertyListXMLFormat_v1_0]);
 
-    dispatch_async(dispatch_get_main_queue(), ^()
-    {
-        [[NSNotificationCenter defaultCenter] 
-            postNotificationName: COStorePersistentRootsDidChangeNotification
-                          object: self
-                        userInfo: userInfo];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName: COStorePersistentRootsDidChangeNotification
+                      object: self
+                    userInfo: userInfo];
 
-        [[CODistributedNotificationCenter defaultCenter]
-            postNotificationName: COStorePersistentRootsDidChangeNotification
-                          object: [self.UUID stringValue]
-                        userInfo: userInfo
-              deliverImmediately: YES];
-    });
+    [[CODistributedNotificationCenter defaultCenter]
+        postNotificationName: COStorePersistentRootsDidChangeNotification
+                      object: [self.UUID stringValue]
+                    userInfo: userInfo
+          deliverImmediately: YES];
 }
 
 - (void)postCommitNotificationsWithTransactionIDForPersistentRootUUID: (NSDictionary *)txnIDForPersistentRoot


### PR DESCRIPTION
For Toukan, I have a high-level construct called `StoreView` which is roughly equivalent to `COEditingContext`. 

When importing documents or loading templates (on launch), I spawn a task/operation per document/template to import. I run all these tasks in parallel. Each task creates its own store view, because its API is more convenient to use than `COSQLiteStore`. As a result, I end up with a single `COSQLiteStore` instance that is shared between different stores views (the main store view along the ones created in import tasks).

With the `COSQLite` implementation, committing from a background thread/queue would cause an assertion (due to `-[NSThread isMainThread] `being enforced when posting commit notifications). Removing the assertion proved to be not enough to support editing contexts or store views in background threads, because I could receive out of order notifications and end up with invalid transaction IDs in each store view.

I tried to force every commit notifications through a main queue, but this was cumbersome to use in test. In the end, I opted for a different approach that maintains the existing API behavior when used from the main thread. To do so, I have introduced:
- commit lock in `COSQLiteStore` that wraps committing store transaction and posting commit notification
- delivery queue for commit notifications in `COEditingContext` and `StoreView`