### PR TITLE
Improve revision checks with persistent roots at store level

### DIFF
--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -744,8 +744,6 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
     {
         NSLog(@"Parent revision not found: %@", aParent);
         return NO;
-        // FIXME: If we're going to support writing revisions with missing parents
-        // we should probably preserve the parent UUID?
     }
     if (aMergeParent != nil && mergeParentRevid == -1)
     {

--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -743,12 +743,14 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
     if (aParent != nil && parentRevid == -1)
     {
         NSLog(@"Parent revision not found: %@", aParent);
+        return NO;
         // FIXME: If we're going to support writing revisions with missing parents
         // we should probably preserve the parent UUID?
     }
     if (aMergeParent != nil && mergeParentRevid == -1)
     {
         NSLog(@"Merge parent revision not found: %@", aMergeParent);
+        return NO;
     }
 
     const BOOL ok = [backing writeItemGraph: anItemTree

--- a/Store/COSQLiteStore.m
+++ b/Store/COSQLiteStore.m
@@ -418,7 +418,7 @@ NSString *const COPersistentRootAttributeUsedSize = @"COPersistentRootAttributeU
     dispatch_sync(queue_, ^()
     {
         COSQLiteStorePersistentRootBackingStore *backingStore =
-            [self backingStoreForPersistentRootUUID: prootUUID createIfNotPresent: YES];
+            [self backingStoreForPersistentRootUUID: prootUUID createIfNotPresent: NO];
 
         result = [backingStore revisionInfosForBranchUUID: aBranchUUID
                                          headRevisionUUID: headRevUUID

--- a/Synchronization/COSynchronizerClient.m
+++ b/Synchronization/COSynchronizerClient.m
@@ -99,7 +99,8 @@
     {
         [message.currentRevision writeToTransaction: txn
                                  persistentRootUUID: message.persistentRootUUID
-                                         branchUUID: message.branchUUID];
+                                         branchUUID: message.branchUUID
+                                    isFirstRevision: YES];
     }
 
     ETAssert([_ctx.store commitStoreTransaction: txn]);
@@ -197,7 +198,8 @@
         {
             [rev writeToTransaction: txn
                  persistentRootUUID: self.persistentRoot.UUID
-                         branchUUID: self.branch.UUID];
+                         branchUUID: self.branch.UUID
+                    isFirstRevision: NO];
         }
     }
     // TODO: Ideally we'd just do one store commit, instead of two,

--- a/Synchronization/COSynchronizerServer.m
+++ b/Synchronization/COSynchronizerServer.m
@@ -74,7 +74,8 @@
     {
         [rev writeToTransaction: txn
              persistentRootUUID: self.persistentRoot.UUID
-                     branchUUID: self.branch.UUID];
+                     branchUUID: self.branch.UUID
+                isFirstRevision: NO];
     }
     ETAssert([self.persistentRoot.store commitStoreTransaction: txn]);
 

--- a/Synchronization/Messages/COSynchronizerRevision.h
+++ b/Synchronization/Messages/COSynchronizerRevision.h
@@ -25,7 +25,8 @@
 
 - (void)writeToTransaction: (COStoreTransaction *)txn
         persistentRootUUID: (ETUUID *)persistentRoot
-                branchUUID: (ETUUID *)branch;
+                branchUUID: (ETUUID *)branch
+           isFirstRevision: (BOOL)isFirst;
 - (instancetype)initWithUUID: (ETUUID *)aUUID
               persistentRoot: (ETUUID *)aPersistentRoot
                        store: (COSQLiteStore *)store

--- a/Synchronization/Messages/COSynchronizerRevision.m
+++ b/Synchronization/Messages/COSynchronizerRevision.m
@@ -16,11 +16,12 @@
 - (void)writeToTransaction: (COStoreTransaction *)txn
         persistentRootUUID: (ETUUID *)persistentRoot
                 branchUUID: (ETUUID *)branch
+           isFirstRevision: (BOOL)isFirst
 {
     [txn writeRevisionWithModifiedItems: self.modifiedItems
                            revisionUUID: self.revisionUUID
                                metadata: self.metadata
-                       parentRevisionID: self.parentRevisionUUID
+                       parentRevisionID: isFirst ? nil : self.parentRevisionUUID
                   mergeParentRevisionID: nil
                      persistentRootUUID: persistentRoot
                              branchUUID: branch];

--- a/Tests/Store/TestSQLiteStore.m
+++ b/Tests/Store/TestSQLiteStore.m
@@ -1065,10 +1065,6 @@ static ETUUID *childUUID2;
 - (void)testWriteRevisionWithNonExistentParent
 {
     COStoreTransaction *txn = [[COStoreTransaction alloc] init];
-
-    // N.B. If the parent revision is not in the store, you have to provide all items
-    // in the revision (not just a delta against the parent)
-
     [txn writeRevisionWithModifiedItems: [self makeBranchAItemTreeAtIndex: BRANCH_LATER]
                            revisionUUID: [ETUUID UUID]
                                metadata: nil
@@ -1077,7 +1073,7 @@ static ETUUID *childUUID2;
                      persistentRootUUID: prootUUID
                              branchUUID: branchAUUID];
     prootChangeCount = [txn setOldTransactionID: prootChangeCount forPersistentRoot: prootUUID];
-    UKTrue([store commitStoreTransaction: txn]);
+    UKFalse([store commitStoreTransaction: txn]);
 }
 
 - (void)testWriteRevisionWithNonExistentMergeParent
@@ -1091,7 +1087,7 @@ static ETUUID *childUUID2;
                      persistentRootUUID: prootUUID
                              branchUUID: branchAUUID];
     prootChangeCount = [txn setOldTransactionID: prootChangeCount forPersistentRoot: prootUUID];
-    UKTrue([store commitStoreTransaction: txn]);
+    UKFalse([store commitStoreTransaction: txn]);
 }
 
 /**


### PR DESCRIPTION
Hey Eric,

This PR contains two changes:
1. Change `-[COSQLite revisionInfosForBranchUUID:]` to avoid creating backing store when retrieving revisions for a persistent root that doesn't exists
2. Prevent writing revision with a parent revision that doesn't exist

The first change means high-level constructs such as `COEditingContext` don't have to worry about asking revisions for a non-existent branch (e.g. not yet committed or finalized). I was needing this to change how importing documents behave in Toukan, depending on whether the document already exists or not in store.

The second change is to prevent committing when previous revisions are missing. When writing `StoreView` ( `COEditingContext` equivalent in Toukan), I had a hard to track bug where the item graph loading was failing due to missing items. These items were missing, because I didn't catch some commit failures and the persistent root history ended up with holes due to missing revisions.

The second change impacts the synchronizer code I don't know well. From what I understand, the only time where a non-existent parent revision had to be passed, was when the client is creating the server branch (setup phase) and writing the first revision to it. This first revision has a parent revision that only exists in the server side. To cope with this, I added an argument `isFirstRevision` to `-[COSynchronizerRevision writeToTransaction:persistentRootUUID:branchUUID:isFirstRevision:]`. 
Is this only case where a non-existent parent revision could be passed to -[COSQLiteStore writeModifiedItems:…]?