### PR TITLE
Shorter internal key prefixes in COItem

### DIFF
--- a/StorageDataModel/COItem.h
+++ b/StorageDataModel/COItem.h
@@ -13,6 +13,9 @@
 extern NSString *const kCOItemEntityNameProperty;
 extern NSString *const kCOItemPackageVersionProperty;
 extern NSString *const kCOItemPackageNameProperty;
+extern NSString *const kCOItemDeprecatedEntityNameProperty;
+extern NSString *const kCOItemDeprecatedPackageVersionProperty;
+extern NSString *const kCOItemDeprecatedPackageNameProperty;
 extern NSString *const kCOItemIsSharedProperty;
 
 /**

--- a/StorageDataModel/COItem.m
+++ b/StorageDataModel/COItem.m
@@ -11,9 +11,12 @@
 #import "COPath.h"
 #import "COAttachmentID.h"
 
-NSString *const kCOItemEntityNameProperty = @"org.etoile-project.coreobject.entityname";
-NSString *const kCOItemPackageVersionProperty = @"org.etoile-project.coreobject.packageversion";
-NSString *const kCOItemPackageNameProperty = @"org.etoile-project.coreobject.packagename";
+NSString *const kCOItemEntityNameProperty = @"_entityName";
+NSString *const kCOItemPackageVersionProperty = @"_packageVersion";
+NSString *const kCOItemPackageNameProperty = @"_packageName";
+NSString *const kCOItemDeprecatedEntityNameProperty = @"org.etoile-project.coreobject.entityname";
+NSString *const kCOItemDeprecatedPackageVersionProperty = @"org.etoile-project.coreobject.packageversion";
+NSString *const kCOItemDeprecatedPackageNameProperty = @"org.etoile-project.coreobject.packagename";
 NSString *const kCOItemIsSharedProperty = @"isShared";
 
 static NSDictionary *copyValueDictionary(NSDictionary *input, BOOL mutable)

--- a/StorageDataModel/COItem.m
+++ b/StorageDataModel/COItem.m
@@ -11,9 +11,9 @@
 #import "COPath.h"
 #import "COAttachmentID.h"
 
-NSString *const kCOItemEntityNameProperty = @"_entityName";
-NSString *const kCOItemPackageVersionProperty = @"_packageVersion";
-NSString *const kCOItemPackageNameProperty = @"_packageName";
+NSString *const kCOItemEntityNameProperty = @"_entity-name";
+NSString *const kCOItemPackageVersionProperty = @"_package-version";
+NSString *const kCOItemPackageNameProperty = @"_package-name";
 NSString *const kCOItemDeprecatedEntityNameProperty = @"org.etoile-project.coreobject.entityname";
 NSString *const kCOItemDeprecatedPackageVersionProperty = @"org.etoile-project.coreobject.packageversion";
 NSString *const kCOItemDeprecatedPackageNameProperty = @"org.etoile-project.coreobject.packagename";

--- a/Store/COItem+Binary.m
+++ b/Store/COItem+Binary.m
@@ -428,6 +428,29 @@ static void co_read_null(void *ctx)
     }
 }
 
+// Migrate internal DNS prefixed keys (old format) to underscore prefixed keys (new format)
+static void migrateInternalKeysFromOldToNewFormat(NSMutableDictionary *values, NSMutableDictionary *types) {
+    if (values[kCOItemEntityNameProperty] != nil)
+    {
+        return;
+    }
+    values[kCOItemEntityNameProperty] = values[kCOItemDeprecatedEntityNameProperty];
+    values[kCOItemPackageNameProperty] = values[kCOItemDeprecatedPackageNameProperty];
+    values[kCOItemPackageVersionProperty] = values[kCOItemDeprecatedPackageVersionProperty];
+    
+    [values removeObjectForKey: kCOItemDeprecatedEntityNameProperty];
+    [values removeObjectForKey: kCOItemDeprecatedPackageNameProperty];
+    [values removeObjectForKey: kCOItemDeprecatedPackageVersionProperty];
+    
+    types[kCOItemEntityNameProperty] = types[kCOItemDeprecatedEntityNameProperty];
+    types[kCOItemPackageNameProperty] = types[kCOItemDeprecatedPackageNameProperty];
+    types[kCOItemPackageVersionProperty] = types[kCOItemDeprecatedPackageVersionProperty];
+
+    [types removeObjectForKey: kCOItemDeprecatedEntityNameProperty];
+    [types removeObjectForKey: kCOItemDeprecatedPackageNameProperty];
+    [types removeObjectForKey: kCOItemDeprecatedPackageVersionProperty];
+}
+
 /* Initializers in categories cannot be marked with NS_DESIGNATED_INITIALIZER */
 #pragma clang diagnostic ignored "-Wobjc-designated-initializers"
 
@@ -456,9 +479,10 @@ static void co_read_null(void *ctx)
     uuid = state->uuid;
     types = state->types;
     values = state->values;
-
+    
+    migrateInternalKeysFromOldToNewFormat(values, types);
+    
     return self;
 }
 
 @end
-


### PR DESCRIPTION
Hey Eric,

Existing default key prefixes in COItem are quite long. When working with big object/item graphs in Toukan, I found this makes debugging output more verbose and harder to go through quickly. So I'd like to remove the reverse DNS key prefix and simply use an underscore as prefix. The underscore as prefix would be reserved for CoreObject.

For the short term, I changed the deserialization logic to check whether an item is encoded with the old prefixes or the new ones. When old prefixes are used, I manually replace the old keys with new keys in both `COItem.values` and `COItem.types` dictionaries. This replacing is probably going to hurt performance when loading big item graphs, but I'm ok with it in the short term. My plan is to keep in the coming months, then remove it once:
- everything works well
- documents have been all snapshotted with these new prefixes
- past document histories have been compacted (eliminating items in store using the old prefixes).

Once I remove it, it would break compatibility with existing CoreObject stores you might have still around. Is it an issue for you?

---

The new current internal key prefixes common to both JSON and Binary formats are:
- _entityName
- _packageName
- _packageVersion

Two more internal keys exists only for JSON format:
- _uuid
- _json-format

As you can see, there is a slight mismatch in term of naming styles:
- dash -> _json-format
- camel case -> _entityName

I could use dash everywhere for internal keys:
- _entity-name
- _package-name
- _package-version
- _uuid
- _json-format

Not sure whether it's a good idea, since we use camel case in the API and when serializing ObjC/Swift objects. If we were serializing model objects in other languages or porting CO to other languages, the property naming could be in another style, so standardizing on ObjC/Swift naming style might not be important.

The JSON format also encodes the multivalued property types using dash. For example: _string-array_

So I see 5 possible choices:
1. leave it as it is in the PR currently
2. name every internal keys with dash
3. rename *_json-format* to *_jsonFormat*, but leave other multivalue type keys as they are
4. name every internal keys with camel case (including multivalued type keys in JSON format)

Given that choice 3 creates incoherencies inside the JSON format and 4 is way too much work and troubles, I'd go for 1 or 2. What do you prefer?