### PR TITLE
New JSON-based and tree-structured description for debugging item graphs

### DIFF
--- a/StorageDataModel/COItemGraph.h
+++ b/StorageDataModel/COItemGraph.h
@@ -133,6 +133,24 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
+ * Returns a JSON representation for the entire item graph, where composite references are replaced
+ * with items encoded as JSON dictionaries.
+ *
+ * Objects referenced through composite references don't appear at the top level, unlike in the
+ * default item graph JSON representation.
+ *
+ * The returned JSON is similar to COItemGraphToJSONPropertyList().
+ */
+NSString *COTreeJSONDescription(id <COItemGraph>aGraph);
+/**
+ * Returns a JSON representation for the given item, where composite references are replaced with
+ * items encoded as JSON dictionaries.
+ *
+ * The returned JSON is similar to -[COItem JSONPlist].
+ */
+NSString *COTreeJSONDescriptionFromItem(id <COItemGraph>aGraph, COItem *anItem);
+
+/**
  * For debugging.
  */
 void COValidateItemGraph(id <COItemGraph> aGraph);


### PR DESCRIPTION
I had troubles to debug item/object graphs in Toukan. Almost all references are composite in a Toukan document, so presenting composite items nested inside other items make debugging much easier.

To do so, I came up with a new JSON description for item graphs, that is loosely based on the built-in item JSON format. I decided to use JSON, in order to support copying/pasting the description into a JSON editor/outliner. This makes it easy to inspect the tree structure and collapse/expand the parts of the tree in whatever way I need.

Here is a simple output example:

```json
{
  "objects" : {
    "4ef7a49a-653f-4f10-69d4-10b3888fb96d" : {
      "_uuid" : "4ef7a49a-653f-4f10-69d4-10b3888fb96d",
      "_package-name (string)" : "io.toukan.document",
      "_package-version (int)" : 5,
      "_entity-name (string)" : "Node"
      "children (composite-array)" : [
        {
            "_uuid" : "4ef7a49a-653f-4f10-69d4-10b3888fb96d",
            "_package-name (string)" : "io.toukan.document",
            "_package-version (int)" : 5,
            "_entity-name (string)" : "Node"
            "chidren (composite-array)" : []
        }
      ]
    },
  },
  "rootObjectUUID" : "4ef7a49a-653f-4f10-69d4-10b3888fb96d"
}
```

Here is a part of a Toukan document copied/pasted inside a JSON outliner:

![Capture d’écran 2024-02-19 à 19 11 48](https://github.com/etoile/CoreObject/assets/74360/e33014d9-ecdf-42e3-a08d-989aec3ac34d)
