### PR TITLE
Add options to control COCopier behavior and fix copying non-composite references

### DIFF
--- a/Benchmark/TestAttributedStringDiffPerformance.m
+++ b/Benchmark/TestAttributedStringDiffPerformance.m
@@ -43,9 +43,8 @@
 {
     NSDate *start = [NSDate date];
     COObjectGraphContext *tempObjectGraph = [COObjectGraphContext new];
-    COCopierOptions options = COCopierUsesNewUUIDs
-        | COCopierCopiesNonCompositeReferencesMissingInDestination
-        | COCopierCopiesNonCompositeReferencesExistingInDestination;
+    COCopierOptions options = COCopierCopiesNonCompositeReferencesMissingInDestination
+                            | COCopierCopiesNonCompositeReferencesExistingInDestination;
 
     (void)[[COCopier new] copyItemWithUUID: objectGraph.rootItemUUID
                                  fromGraph: objectGraph

--- a/Benchmark/TestAttributedStringDiffPerformance.m
+++ b/Benchmark/TestAttributedStringDiffPerformance.m
@@ -43,10 +43,14 @@
 {
     NSDate *start = [NSDate date];
     COObjectGraphContext *tempObjectGraph = [COObjectGraphContext new];
+    COCopierOptions options = COCopierUsesNewUUIDs
+        | COCopierCopiesNonCompositeReferencesMissingInDestination
+        | COCopierCopiesNonCompositeReferencesExistingInDestination;
 
     (void)[[COCopier new] copyItemWithUUID: objectGraph.rootItemUUID
                                  fromGraph: objectGraph
-                                   toGraph: tempObjectGraph];
+                                   toGraph: tempObjectGraph
+                                   options: options];
 
     NSTimeInterval time = [[NSDate date] timeIntervalSinceDate: start];
     return time;

--- a/Core/COCopier.h
+++ b/Core/COCopier.h
@@ -16,12 +16,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef NS_OPTIONS(NSInteger, COCopierOptions) {
     /**
-     ** Whether copies have different UUIDs in destination than original items in source.
+     * Whether copies keep using the same UUIDs in destination than original items in source.
      *
-     * This is useful to duplicate items when source and destination are the same. You can also use 
-     * it to implement copy/paste semantics whether source and destination are the same or not.
+     * You should omit this option to implement cut/copy/paste semantics, whether source and 
+     * destination are the same or not.
      */
-    COCopierUsesNewUUIDs = 2,
+    COCopierReusesSourceUUIDs = 2,
     /**
      * Whether items reachable through non composite references are copied, when they dont'
      * exist in the destination.
@@ -62,8 +62,6 @@ typedef NS_OPTIONS(NSInteger, COCopierOptions) {
  * destination item graph.
  *
  * If source and destination item graphs are identical, the item is duplicated.
- *
- * COCopierUsesNewUUIDs option is used. For more control over COCopier options, use -copyItemWithUUID:fromGraph:toGraph:options:.
  */
 - (ETUUID *)copyItemWithUUID: (ETUUID *)aUUID
                    fromGraph: (id <COItemGraph>)source

--- a/Core/COCopier.h
+++ b/Core/COCopier.h
@@ -13,6 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Options to control COCopier behavior.
+ *
+ * If COCopierCopiesNonCompositeReferencesExistingInDestination is not among copy options,
+ * kCOIsSharedItemProperty can be set to NO to copy an existing item rather an aliasing it.
  */
 typedef NS_OPTIONS(NSInteger, COCopierOptions) {
     /**
@@ -37,6 +40,11 @@ typedef NS_OPTIONS(NSInteger, COCopierOptions) {
      * the destination.
      *
      * Be careful with this option, the entire source item graph can be copied into the destination.
+     *
+     * If COCopierReusesSourceUUID is used, then copying updates existing items in the destination
+     * rather than creating new items.
+     *
+     * This option causes kCOIsSharedItemProperty to be ignored.
      *
      * You should usually not use it alone, but in combination with
      * COCopierCopiesNonCompositeReferencesMissingInDestination.

--- a/Core/COCopier.h
+++ b/Core/COCopier.h
@@ -58,7 +58,7 @@ typedef NS_OPTIONS(NSInteger, COCopierOptions) {
 @interface COCopier : NSObject
 
 /**
- * Copies a single item between two item graphs and returns the UUID of the item inserted in the
+ * Copies a single item between two item graphs and returns the UUID of these items in the
  * destination item graph.
  *
  * If source and destination item graphs are identical, the item is duplicated.
@@ -67,7 +67,7 @@ typedef NS_OPTIONS(NSInteger, COCopierOptions) {
                    fromGraph: (id <COItemGraph>)source
                      toGraph: (id <COItemGraph>)dest NS_RETURNS_NOT_RETAINED;
 /**
- * Copies a single item between two item graphs and returns the UUID of the item inserted in the 
+ * Copies a single item between two item graphs and returns the UUID of these item in the 
  * destination item graph.
  *
  * If source and destination item graphs are identical, the item is duplicated.
@@ -77,8 +77,8 @@ typedef NS_OPTIONS(NSInteger, COCopierOptions) {
                      toGraph: (id <COItemGraph>)dest
                      options: (COCopierOptions)options NS_RETURNS_NOT_RETAINED;
 /**
- * Copies the given items between two item graphs and returns the UUIDs of the items inserted in 
- * the destination item graph.
+ * Copies the given items between two item graphs and returns the UUIDs of these items in the
+ * destination item graph.
  *
  * If source and destination item graphs are identical, the items are duplicated.
  */

--- a/Core/COCopier.h
+++ b/Core/COCopier.h
@@ -41,7 +41,7 @@ typedef NS_OPTIONS(NSInteger, COCopierOptions) {
      * You should usually not use it alone, but in combination with
      * COCopierCopiesNonCompositeReferencesMissingInDestination.
      */
-    COCopierCopiesNonCompositeReferencesExistingInDestination = 8
+    COCopierCopiesNonCompositeReferencesExistingInDestination = 16
 };
 
 /**

--- a/Core/COCopier.h
+++ b/Core/COCopier.h
@@ -12,6 +12,39 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ * Options to control COCopier behavior.
+ */
+typedef NS_OPTIONS(NSInteger, COCopierOptions) {
+    /**
+     ** Whether copies have different UUIDs in destination than original items in source.
+     *
+     * This is useful to duplicate items when source and destination are the same. You can also use 
+     * it to implement copy/paste semantics whether source and destination are the same or not.
+     */
+    COCopierUsesNewUUIDs = 2,
+    /**
+     * Whether items reachable through non composite references are copied, when they dont'
+     * exist in the destination.
+     *
+     * Be careful with this option, the entire source item graph can be copied into the destination.
+     *
+     * Can be used alone and in combination with
+     * COCopierCopiesNonCompositeReferencesExistingInDestination.
+     */
+    COCopierCopiesNonCompositeReferencesMissingInDestination = 4,
+    /**
+     * Whether items reachable through non composite references are copied, when they exist in the
+     * the destination.
+     *
+     * Be careful with this option, the entire source item graph can be copied into the destination.
+     *
+     * You should usually not use it alone, but in combination with
+     * COCopierCopiesNonCompositeReferencesMissingInDestination.
+     */
+    COCopierCopiesNonCompositeReferencesExistingInDestination = 8
+};
+
+/**
  * @group Core
  * @abstract Metamodel-driven copy support
  *
@@ -25,6 +58,17 @@ NS_ASSUME_NONNULL_BEGIN
 @interface COCopier : NSObject
 
 /**
+ * Copies a single item between two item graphs and returns the UUID of the item inserted in the
+ * destination item graph.
+ *
+ * If source and destination item graphs are identical, the item is duplicated.
+ *
+ * COCopierUsesNewUUIDs option is used. For more control over COCopier options, use -copyItemWithUUID:fromGraph:toGraph:options:.
+ */
+- (ETUUID *)copyItemWithUUID: (ETUUID *)aUUID
+                   fromGraph: (id <COItemGraph>)source
+                     toGraph: (id <COItemGraph>)dest NS_RETURNS_NOT_RETAINED;
+/**
  * Copies a single item between two item graphs and returns the UUID of the item inserted in the 
  * destination item graph.
  *
@@ -32,7 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ETUUID *)copyItemWithUUID: (ETUUID *)aUUID
                    fromGraph: (id <COItemGraph>)source
-                     toGraph: (id <COItemGraph>)dest NS_RETURNS_NOT_RETAINED;
+                     toGraph: (id <COItemGraph>)dest
+                     options: (COCopierOptions)options NS_RETURNS_NOT_RETAINED;
 /**
  * Copies the given items between two item graphs and returns the UUIDs of the items inserted in 
  * the destination item graph.
@@ -41,7 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSArray<ETUUID *> *)copyItemsWithUUIDs: (NSArray<ETUUID *> *)uuids
                                 fromGraph: (id <COItemGraph>)source
-                                  toGraph: (id <COItemGraph>)dest NS_RETURNS_NOT_RETAINED;
+                                  toGraph: (id <COItemGraph>)dest 
+                                  options: (COCopierOptions)options NS_RETURNS_NOT_RETAINED;
 
 @end
 

--- a/Core/COCopier.m
+++ b/Core/COCopier.m
@@ -189,7 +189,7 @@
 
     [dest insertOrUpdateItems: items];
 
-    return itemUUIDs;
+    return [uuids mappedCollectionWithBlock: ^(id inputUUID) { return mapping[inputUUID]; }];
 }
 
 @end

--- a/Core/COCopier.m
+++ b/Core/COCopier.m
@@ -147,7 +147,7 @@
     return [self copyItemsWithUUIDs: @[aUUID]
                           fromGraph: source
                             toGraph: dest
-                            options: COCopierUsesNewUUIDs][0];
+                            options: 0][0];
 }
 
 - (NSArray *)copyItemsWithUUIDs: (NSArray *)uuids
@@ -173,7 +173,7 @@
 
     for (ETUUID *oldUUID in uuidsToCopy)
     {
-        mapping[oldUUID] = (options & COCopierUsesNewUUIDs) ? [ETUUID UUID] : oldUUID;
+        mapping[oldUUID] = (options & COCopierReusesSourceUUIDs) ? oldUUID :  [ETUUID UUID];
     }
 
     NSMutableArray *items = [NSMutableArray array];

--- a/Core/COCopier.m
+++ b/Core/COCopier.m
@@ -177,7 +177,6 @@
     }
 
     NSMutableArray *items = [NSMutableArray array];
-    NSMutableArray *itemUUIDs = [NSMutableArray array];
 
     for (ETUUID *uuid in uuidsToCopy)
     {
@@ -185,7 +184,6 @@
         COItem *newItem = [oldItem mutableCopyWithUUIDMapping: mapping];
 
         [items addObject: newItem];
-        [itemUUIDs addObject: newItem.UUID];
     }
 
     [dest insertOrUpdateItems: items];

--- a/Core/COCopier.m
+++ b/Core/COCopier.m
@@ -111,7 +111,8 @@
     BOOL copiesNonCompositeReferences = (options & COCopierCopiesNonCompositeReferencesMissingInDestination)
                                      || (options & COCopierCopiesNonCompositeReferencesExistingInDestination);
     
-    if (copiesNonCompositeReferences) {
+    if (copiesNonCompositeReferences)
+    {
         for (ETUUID *uuid in compositeItemUUIDs)
         {
             [self collectNonCompositeItemUUIDsToCopyForItem: [source itemForUUID: uuid]

--- a/Extras/Model/COAttributedString.m
+++ b/Extras/Model/COAttributedString.m
@@ -98,7 +98,8 @@
     COCopier *copier = [COCopier new];
     NSArray *copiedUUIDs = [copier copyItemsWithUUIDs: chunkUUIDS
                                             fromGraph: self.objectGraphContext
-                                              toGraph: result];
+                                              toGraph: result
+                                              options: COCopierUsesNewUUIDs];
 
     // Trim off excess characters
 
@@ -210,7 +211,8 @@
     COCopier *copier = [COCopier new];
     ETUUID *rightChunkUUID = [copier copyItemWithUUID: chunk.UUID
                                             fromGraph: self.objectGraphContext
-                                              toGraph: self.objectGraphContext];
+                                              toGraph: self.objectGraphContext
+                                              options: COCopierUsesNewUUIDs];
     COAttributedStringChunk *rightChunk = [self.objectGraphContext loadedObjectForUUID: rightChunkUUID];
     rightChunk.text = rightString;
 

--- a/Extras/Model/COAttributedString.m
+++ b/Extras/Model/COAttributedString.m
@@ -96,9 +96,8 @@
                                      excessCharactersAtEnd: &excessAtEnd];
 
     COCopier *copier = [COCopier new];
-    COCopierOptions options = COCopierUsesNewUUIDs
-        | COCopierCopiesNonCompositeReferencesMissingInDestination
-        | COCopierCopiesNonCompositeReferencesExistingInDestination;
+    COCopierOptions options = COCopierCopiesNonCompositeReferencesMissingInDestination
+                            | COCopierCopiesNonCompositeReferencesExistingInDestination;
     NSArray *copiedUUIDs = [copier copyItemsWithUUIDs: chunkUUIDS
                                             fromGraph: self.objectGraphContext
                                               toGraph: result
@@ -210,9 +209,8 @@
     // attributes.
 
     COCopier *copier = [COCopier new];
-    COCopierOptions options = COCopierUsesNewUUIDs
-        | COCopierCopiesNonCompositeReferencesMissingInDestination
-        | COCopierCopiesNonCompositeReferencesExistingInDestination;
+    COCopierOptions options = COCopierCopiesNonCompositeReferencesMissingInDestination
+                            | COCopierCopiesNonCompositeReferencesExistingInDestination;
     ETUUID *rightChunkUUID = [copier copyItemWithUUID: chunk.UUID
                                             fromGraph: self.objectGraphContext
                                               toGraph: self.objectGraphContext

--- a/Extras/Model/COAttributedString.m
+++ b/Extras/Model/COAttributedString.m
@@ -96,10 +96,13 @@
                                      excessCharactersAtEnd: &excessAtEnd];
 
     COCopier *copier = [COCopier new];
+    COCopierOptions options = COCopierUsesNewUUIDs
+        | COCopierCopiesNonCompositeReferencesMissingInDestination
+        | COCopierCopiesNonCompositeReferencesExistingInDestination;
     NSArray *copiedUUIDs = [copier copyItemsWithUUIDs: chunkUUIDS
                                             fromGraph: self.objectGraphContext
                                               toGraph: result
-                                              options: COCopierUsesNewUUIDs];
+                                              options: options];
 
     // Trim off excess characters
 
@@ -205,14 +208,15 @@
 
     // Create a new chunk for the right side, copying from the left side so we also copy the
     // attributes.
-    // FIXME: Since attributes aren't referred to with a composite rel'n, currently
-    // they are being aliased and not copied.
 
     COCopier *copier = [COCopier new];
+    COCopierOptions options = COCopierUsesNewUUIDs
+        | COCopierCopiesNonCompositeReferencesMissingInDestination
+        | COCopierCopiesNonCompositeReferencesExistingInDestination;
     ETUUID *rightChunkUUID = [copier copyItemWithUUID: chunk.UUID
                                             fromGraph: self.objectGraphContext
                                               toGraph: self.objectGraphContext
-                                              options: COCopierUsesNewUUIDs];
+                                              options: options];
     COAttributedStringChunk *rightChunk = [self.objectGraphContext loadedObjectForUUID: rightChunkUUID];
     rightChunk.text = rightString;
 

--- a/Extras/Model/COAttributedStringAttribute.m
+++ b/Extras/Model/COAttributedStringAttribute.m
@@ -40,7 +40,8 @@
     COCopier *copier = [COCopier new];
     ETUUID *copyUUID = [copier copyItemWithUUID: self.UUID
                                       fromGraph: self.objectGraphContext
-                                        toGraph: result];
+                                        toGraph: result
+                                        options: COCopierUsesNewUUIDs];
     result.rootItemUUID = copyUUID;
 
     return result;

--- a/Extras/Model/COAttributedStringAttribute.m
+++ b/Extras/Model/COAttributedStringAttribute.m
@@ -38,9 +38,8 @@
     COItemGraph *result = [[COItemGraph alloc] init];
 
     COCopier *copier = [COCopier new];
-    COCopierOptions options = COCopierUsesNewUUIDs
-        | COCopierCopiesNonCompositeReferencesMissingInDestination
-        | COCopierCopiesNonCompositeReferencesExistingInDestination;
+    COCopierOptions options = COCopierCopiesNonCompositeReferencesMissingInDestination
+                            | COCopierCopiesNonCompositeReferencesExistingInDestination;
     ETUUID *copyUUID = [copier copyItemWithUUID: self.UUID
                                       fromGraph: self.objectGraphContext
                                         toGraph: result

--- a/Extras/Model/COAttributedStringAttribute.m
+++ b/Extras/Model/COAttributedStringAttribute.m
@@ -38,10 +38,13 @@
     COItemGraph *result = [[COItemGraph alloc] init];
 
     COCopier *copier = [COCopier new];
+    COCopierOptions options = COCopierUsesNewUUIDs
+        | COCopierCopiesNonCompositeReferencesMissingInDestination
+        | COCopierCopiesNonCompositeReferencesExistingInDestination;
     ETUUID *copyUUID = [copier copyItemWithUUID: self.UUID
                                       fromGraph: self.objectGraphContext
                                         toGraph: result
-                                        options: COCopierUsesNewUUIDs];
+                                        options: options];
     result.rootItemUUID = copyUUID;
 
     return result;

--- a/Extras/Model/COAttributedStringChunk.m
+++ b/Extras/Model/COAttributedStringChunk.m
@@ -46,11 +46,13 @@
 {
     COItemGraph *result = [[COItemGraph alloc] init];
     COCopier *copier = [[COCopier alloc] init];
-
+    COCopierOptions options = COCopierUsesNewUUIDs
+        | COCopierCopiesNonCompositeReferencesMissingInDestination
+        | COCopierCopiesNonCompositeReferencesExistingInDestination;
     ETUUID *copyRootUUID = [copier copyItemWithUUID: self.UUID
                                           fromGraph: self.objectGraphContext
                                             toGraph: result
-                                            options: COCopierUsesNewUUIDs];
+                                            options: options];
     result.rootItemUUID = copyRootUUID;
 
     COMutableItem *chunkCopy = [result itemForUUID: copyRootUUID];

--- a/Extras/Model/COAttributedStringChunk.m
+++ b/Extras/Model/COAttributedStringChunk.m
@@ -49,7 +49,8 @@
 
     ETUUID *copyRootUUID = [copier copyItemWithUUID: self.UUID
                                           fromGraph: self.objectGraphContext
-                                            toGraph: result];
+                                            toGraph: result
+                                            options: COCopierUsesNewUUIDs];
     result.rootItemUUID = copyRootUUID;
 
     COMutableItem *chunkCopy = [result itemForUUID: copyRootUUID];

--- a/Extras/Model/COAttributedStringChunk.m
+++ b/Extras/Model/COAttributedStringChunk.m
@@ -46,9 +46,8 @@
 {
     COItemGraph *result = [[COItemGraph alloc] init];
     COCopier *copier = [[COCopier alloc] init];
-    COCopierOptions options = COCopierUsesNewUUIDs
-        | COCopierCopiesNonCompositeReferencesMissingInDestination
-        | COCopierCopiesNonCompositeReferencesExistingInDestination;
+    COCopierOptions options = COCopierCopiesNonCompositeReferencesMissingInDestination
+                            | COCopierCopiesNonCompositeReferencesExistingInDestination;
     ETUUID *copyRootUUID = [copier copyItemWithUUID: self.UUID
                                           fromGraph: self.objectGraphContext
                                             toGraph: result

--- a/Samples/ProjectDemo/OutlineController.m
+++ b/Samples/ProjectDemo/OutlineController.m
@@ -739,7 +739,8 @@ objectValueForTableColumn: (NSTableColumn *)column
 
             ETUUID *destUUID = [copier copyItemWithUUID: [outlineItem UUID]
                                               fromGraph: [outlineItem objectGraphContext]
-                                                toGraph: [self objectGraphContext]];
+                                                toGraph: [self objectGraphContext]
+                                                options: COCopierUsesNewUUIDs];
 
             OutlineItem *copy = (OutlineItem *)[[self objectGraphContext] loadedObjectForUUID: destUUID];
 

--- a/Samples/ProjectDemo/OutlineController.m
+++ b/Samples/ProjectDemo/OutlineController.m
@@ -739,8 +739,7 @@ objectValueForTableColumn: (NSTableColumn *)column
 
             ETUUID *destUUID = [copier copyItemWithUUID: [outlineItem UUID]
                                               fromGraph: [outlineItem objectGraphContext]
-                                                toGraph: [self objectGraphContext]
-                                                options: COCopierUsesNewUUIDs];
+                                                toGraph: [self objectGraphContext]];
 
             OutlineItem *copy = (OutlineItem *)[[self objectGraphContext] loadedObjectForUUID: destUUID];
 

--- a/StorageDataModel/COItem.h
+++ b/StorageDataModel/COItem.h
@@ -111,7 +111,7 @@ extern NSString *const kCOItemIsSharedProperty;
 /**
  * Returns a mutable item.
  */
-- (id)mutableCopyWithNameMapping: (NSDictionary *)aMapping;
+- (id)mutableCopyWithUUIDMapping: (NSDictionary *)aMapping;
 
 @end
 

--- a/StorageDataModel/COItem.m
+++ b/StorageDataModel/COItem.m
@@ -237,10 +237,13 @@ static NSDictionary *copyValueDictionary(NSDictionary *input, BOOL mutable)
         COType type = [self typeForAttribute: key];
         if (COTypePrimitivePart(type) == kCOTypeReference)
         {
-            for (ETUUID *embedded in [self allObjectsForAttribute: key])
+            for (id reference in [self allObjectsForAttribute: key])
             {
-                // FIXME: May return COPath!
-                [result addObject: embedded];
+                // Ignore cross-persistent root references
+                if ([reference isKindOfClass: [COPath class]])
+                    continue;
+
+                [result addObject: reference];
             }
         }
     }
@@ -261,10 +264,6 @@ static NSDictionary *copyValueDictionary(NSDictionary *input, BOOL mutable)
             {
                 // Ignore cross-persistent root references
                 if ([aChild isKindOfClass: [COPath class]])
-                    continue;
-
-                // Ignore NSNull (that means the relationship is set to nil)
-                if ([aChild isKindOfClass: [NSNull class]])
                     continue;
 
                 [result addObject: aChild];
@@ -343,7 +342,7 @@ static NSDictionary *copyValueDictionary(NSDictionary *input, BOOL mutable)
                            valuesForAttributes: values];
 }
 
-- (id)mutableCopyWithNameMapping: (NSDictionary *)aMapping
+- (id)mutableCopyWithUUIDMapping: (NSDictionary *)aMapping
 {
     COMutableItem *aCopy = [self mutableCopy];
 

--- a/Tests/Core/TestCopierWithIsShared.m
+++ b/Tests/Core/TestCopierWithIsShared.m
@@ -111,9 +111,11 @@ static NSArray *initialUUIDs;
 - (void)testCopyWithinContext
 {
     UKIntsEqual(9, initialGraph.itemUUIDs.count);
+    COCopierOptions options = COCopierUsesNewUUIDs | COCopierCopiesNonCompositeReferencesMissingInDestination;
     ETUUID *drawing2 = [copier copyItemWithUUID: drawing
                                       fromGraph: initialGraph
-                                        toGraph: initialGraph];
+                                        toGraph: initialGraph
+                                        options: options];
     UKIntsEqual(17, initialGraph.itemUUIDs.count);
 
     // Check structure ("copy semantics.pdf" page 9)
@@ -188,7 +190,8 @@ static NSArray *initialUUIDs;
 
     b.isShared = YES;
 
-    ETUUID *aCopyUUID = [copier copyItemWithUUID: a.UUID fromGraph: ctx toGraph: ctx];
+    COCopierOptions options = COCopierUsesNewUUIDs | COCopierCopiesNonCompositeReferencesMissingInDestination;
+    ETUUID *aCopyUUID = [copier copyItemWithUUID: a.UUID fromGraph: ctx toGraph: ctx options: options];
     id aCopy = [ctx loadedObjectForUUID: aCopyUUID];
 
     UKIntsEqual(3, ctx.itemUUIDs.count);
@@ -206,7 +209,8 @@ static NSArray *initialUUIDs;
 
     b.isShared = NO;
 
-    ETUUID *aCopyUUID = [copier copyItemWithUUID: a.UUID fromGraph: ctx toGraph: ctx];
+    COCopierOptions options = COCopierUsesNewUUIDs | COCopierCopiesNonCompositeReferencesMissingInDestination;
+    ETUUID *aCopyUUID = [copier copyItemWithUUID: a.UUID fromGraph: ctx toGraph: ctx options: options];
     id aCopy = [ctx loadedObjectForUUID: aCopyUUID];
 
     UKIntsEqual(4, ctx.itemUUIDs.count);

--- a/Tests/Core/TestCopierWithIsShared.m
+++ b/Tests/Core/TestCopierWithIsShared.m
@@ -111,7 +111,7 @@ static NSArray *initialUUIDs;
 - (void)testCopyWithinContext
 {
     UKIntsEqual(9, initialGraph.itemUUIDs.count);
-    COCopierOptions options = COCopierUsesNewUUIDs | COCopierCopiesNonCompositeReferencesMissingInDestination;
+    COCopierOptions options = COCopierCopiesNonCompositeReferencesMissingInDestination;
     ETUUID *drawing2 = [copier copyItemWithUUID: drawing
                                       fromGraph: initialGraph
                                         toGraph: initialGraph
@@ -190,7 +190,7 @@ static NSArray *initialUUIDs;
 
     b.isShared = YES;
 
-    COCopierOptions options = COCopierUsesNewUUIDs | COCopierCopiesNonCompositeReferencesMissingInDestination;
+    COCopierOptions options = COCopierCopiesNonCompositeReferencesMissingInDestination;
     ETUUID *aCopyUUID = [copier copyItemWithUUID: a.UUID fromGraph: ctx toGraph: ctx options: options];
     id aCopy = [ctx loadedObjectForUUID: aCopyUUID];
 
@@ -209,7 +209,7 @@ static NSArray *initialUUIDs;
 
     b.isShared = NO;
 
-    COCopierOptions options = COCopierUsesNewUUIDs | COCopierCopiesNonCompositeReferencesMissingInDestination;
+    COCopierOptions options = COCopierCopiesNonCompositeReferencesMissingInDestination;
     ETUUID *aCopyUUID = [copier copyItemWithUUID: a.UUID fromGraph: ctx toGraph: ctx options: options];
     id aCopy = [ctx loadedObjectForUUID: aCopyUUID];
 


### PR DESCRIPTION
The 3 key changes are:
- support copying non-composite references to arbitrary depths (possibly copying the full source item graph)
- new copying behavior options
  - reuse existing source item UUIDs rather than creating new ones
    - can be used to easily clone some part of an item graph (e.g. a composite item tree) without changing its identity
  - choose between copy or alias for non-composite references that exist in the destination
  - choose between copy or ignore for non-composite references that are missing in the destination